### PR TITLE
fix: Logging broken after LogLevel change + add synodsmnotify support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,11 @@ CONFIG_PATH=./config
 # Timezone
 TZ=Europe/Berlin
 
+# Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+LOG_LEVEL=INFO
+
+# Synology DSM notifications (true/false)
+DSM_NOTIFY=false
+
 # Secret key for session encryption (change this!)
 SECRET_KEY=change-me-in-production

--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     backup_path: Path = Path("/backups")
     cookie_directory: Path = Path("/config/sessions")
     log_level: str = "INFO"
+    dsm_notify: bool = False
 
     model_config = {"env_prefix": ""}
 

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ logging.basicConfig(
     level=getattr(logging, settings.log_level.upper(), logging.INFO),
     format="%(asctime)s [%(levelname)s] %(name)s – %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
+    force=True,  # Override uvicorn's default logging setup
 )
 
 # Attach ring buffer handler to the root logger so all messages are captured

--- a/app/routers/backup.py
+++ b/app/routers/backup.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException
 from app import config_store
 from app.schemas import BackupConfigCreate, BackupConfigResponse, BackupTriggerResponse
 from app.services import backup_service, icloud_service
+from app.services.notification import notify_backup_result
 from app.services.scheduler import sync_scheduled_jobs
 
 log = logging.getLogger("icloud-backup")
@@ -92,6 +93,7 @@ async def trigger_backup(apple_id: str):
             stats = None
 
         config_store.update_backup_status(apple_id, status=status, message=message, stats=stats)
+        notify_backup_result(apple_id, status, message)
 
     asyncio.create_task(_run())
 

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -1,0 +1,61 @@
+"""DSM notification service using synodsmnotify."""
+
+import logging
+import shutil
+import subprocess
+
+from app.config import settings
+
+log = logging.getLogger("icloud-backup")
+
+_SYNODSMNOTIFY = "/usr/local/bin/synodsmnotify"
+
+
+def _binary_available() -> bool:
+    """Check whether synodsmnotify is available in the container."""
+    return shutil.which(_SYNODSMNOTIFY) is not None
+
+
+def send_dsm_notification(title: str, message: str) -> None:
+    """Send a DSM notification via synodsmnotify.
+
+    Does nothing when DSM_NOTIFY is disabled or the binary is missing.
+    """
+    if not settings.dsm_notify:
+        return
+
+    if not _binary_available():
+        log.warning(
+            "DSM_NOTIFY ist aktiviert, aber %s wurde nicht gefunden. "
+            "Bitte das Volume /usr/syno/bin/synodsmnotify:%s:ro in "
+            "docker-compose.yml einbinden.",
+            _SYNODSMNOTIFY,
+            _SYNODSMNOTIFY,
+        )
+        return
+
+    try:
+        subprocess.run(
+            [_SYNODSMNOTIFY, "@administrators", title, message],
+            timeout=10,
+            check=True,
+            capture_output=True,
+        )
+        log.info("DSM-Benachrichtigung gesendet: %s", title)
+    except subprocess.CalledProcessError as exc:
+        log.warning("synodsmnotify fehlgeschlagen (rc=%d): %s", exc.returncode, exc.stderr.decode(errors="replace"))
+    except FileNotFoundError:
+        log.warning("synodsmnotify nicht gefunden")
+    except Exception as exc:
+        log.warning("DSM-Benachrichtigung fehlgeschlagen: %s", exc)
+
+
+def notify_backup_result(apple_id: str, status: str, message: str) -> None:
+    """Send a DSM notification summarising a backup result."""
+    if status == "success":
+        title = "iCloud Backup erfolgreich"
+    else:
+        title = "iCloud Backup fehlgeschlagen"
+
+    body = f"{apple_id}: {message}"
+    send_dsm_notification(title, body)

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -9,6 +9,7 @@ from apscheduler.triggers.cron import CronTrigger
 
 from app import config_store
 from app.services import backup_service
+from app.services.notification import notify_backup_result
 
 log = logging.getLogger("icloud-backup")
 
@@ -74,6 +75,7 @@ async def _run_backup_job(apple_id: str) -> None:
         stats = None
 
     config_store.update_backup_status(apple_id, status=status, message=message, stats=stats)
+    notify_backup_result(apple_id, status, message)
 
 
 async def sync_scheduled_jobs() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,11 @@ services:
     volumes:
       - ${BACKUP_PATH:-./backups}:/backups
       - ${CONFIG_PATH:-./config}:/config
+      # Synology DSM notifications (uncomment on Synology NAS)
+      # - /usr/syno/bin/synodsmnotify:/usr/local/bin/synodsmnotify:ro
     environment:
       - TZ=${TZ:-Europe/Berlin}
       - SECRET_KEY=${SECRET_KEY:-change-me-in-production}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - DSM_NOTIFY=${DSM_NOTIFY:-false}
       # - AUTH_PASSWORD=mein-sicheres-passwort  # If not set, a random password is logged on startup


### PR DESCRIPTION
Fix logging.basicConfig() being silently ignored because uvicorn configures the root logger first. Add force=True so LOG_LEVEL env var actually takes effect.

Add DSM notification service (synodsmnotify) that sends Synology NAS notifications after each backup completes (success or error). Disabled by default via DSM_NOTIFY=false.

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc