### PR TITLE
fix: SMS 2FA uses wrong API + photo download writes empty files

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -362,13 +362,13 @@ def _unique_path(path: Path) -> Path:
 def _download_photo(photo, local_path: Path, stats: dict) -> None:
     """Download a single photo asset to *local_path* with atomic write and timestamp."""
     try:
-        download = photo.download()
+        data = photo.download()
     except Exception as exc:
         log.error("Download-Fehler für %s: %s", getattr(photo, "filename", "?"), exc)
         stats["errors"] += 1
         return
 
-    if download is None:
+    if data is None:
         log.warning("Download fehlgeschlagen (None) für %s", getattr(photo, "filename", "?"))
         stats["errors"] += 1
         return
@@ -376,7 +376,7 @@ def _download_photo(photo, local_path: Path, stats: dict) -> None:
     tmp_path = local_path.with_suffix(local_path.suffix + ".tmp")
     try:
         with open(tmp_path, "wb") as fh:
-            copyfileobj(download.raw, fh)
+            fh.write(data)
         tmp_path.rename(local_path)
     except Exception as exc:
         log.error("Schreibfehler für %s: %s", local_path.name, exc)


### PR DESCRIPTION
SMS 2FA: get_trusted_devices() used the old 2SA /listDevices endpoint which returns nothing for modern 2FA (HSA2) accounts. Now reads phone numbers from _auth_data["trustedPhoneNumbers"] and requests SMS via PUT to /verify/phone for 2FA accounts.

Photo download: photo.download() returns bytes, not a Response object. Using copyfileobj(download.raw, fh) caused AttributeError, leaving directories empty. Fixed to fh.write(data).

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc