### PR TITLE
ci: update Docker Hub description from DOCKERHUB.md on publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,3 +53,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          readme-filepath: ./DOCKERHUB.md

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ services:
          - TZ=Europe/Berlin
          - AUTH_PASSWORD=my-secure-password
          - SECRET_KEY=my-secret-key
-        - SYNOLOGY_NOTIFY=true
+         - SYNOLOGY_NOTIFY=true
    ```
 
 5. **Start the project** → Container Manager builds and starts the container


### PR DESCRIPTION
Add peter-evans/dockerhub-description step to sync DOCKERHUB.md to the Docker Hub repository overview after each image push. Also fix YAML indentation in README Synology example.

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc