### PR TITLE
fix: remove cpus limit for Synology kernel compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ services:
        container_name: icloud-backup
        restart: unless-stopped
        mem_limit: 512m
-       cpus: 1.0
        ports:
          - "8080:8080"
        volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: icloud-backup
     restart: unless-stopped
     mem_limit: 512m
-    cpus: 1.0
+    # cpus: 1.0  # Requires kernel CFS scheduler support (not available on all Synology models)
     ports:
       - "${WEB_PORT:-8080}:8080"
     volumes:


### PR DESCRIPTION
The cpus constraint requires kernel CFS scheduler support, which is not available on all Synology NAS models, causing a startup error: "NanoCUs can not be set, as your kernel does not support CPU CFS scheduler"

Keep mem_limit (512 MB) as the primary resource guard — memory exhaustion is the main cause of NAS overload during large backups.

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc