### PR TITLE
feat: configurable sync policy for Drive and Photos (keep/delete/arch…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
 
-VOLUME ["/backups", "/config"]
+VOLUME ["/backups", "/config", "/archive"]
 
 EXPOSE 8080
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     auth_password: str = ""
     config_path: Path = Path("/config")
     backup_path: Path = Path("/backups")
+    archive_path: Path = Path("/archive")
     cookie_directory: Path = Path("/config/sessions")
     log_level: str = "INFO"
     dsm_notify: bool = False
@@ -18,6 +19,7 @@ class Settings(BaseSettings):
     def ensure_directories(self) -> None:
         self.config_path.mkdir(parents=True, exist_ok=True)
         self.backup_path.mkdir(parents=True, exist_ok=True)
+        self.archive_path.mkdir(parents=True, exist_ok=True)
         self.cookie_directory.mkdir(parents=True, exist_ok=True)
 
     def get_auth_password(self) -> str:

--- a/app/config_store.py
+++ b/app/config_store.py
@@ -79,6 +79,8 @@ def _default_backup() -> dict:
         "drive_folders_simple": None,
         "drive_folders_advanced": None,
         "photos_include_family": False,
+        "drive_sync_policy": "delete",
+        "photos_sync_policy": "keep",
         "exclusions": None,
         "destination": "",
         "last_backup_status": "idle",
@@ -197,7 +199,8 @@ def save_backup_config(apple_id: str, config: dict) -> dict | None:
         for key in (
             "backup_drive", "backup_photos", "drive_config_mode",
             "drive_folders_simple", "drive_folders_advanced",
-            "photos_include_family", "exclusions", "destination",
+            "photos_include_family", "drive_sync_policy", "photos_sync_policy",
+            "exclusions", "destination",
         ):
             if key in config:
                 acc["backup"][key] = config[key]

--- a/app/models.py
+++ b/app/models.py
@@ -20,3 +20,9 @@ class BackupStatus(str, enum.Enum):
 class DriveConfigMode(str, enum.Enum):
     SIMPLE = "simple"
     ADVANCED = "advanced"
+
+
+class SyncPolicy(str, enum.Enum):
+    KEEP = "keep"          # Lokal behalten, auch wenn remote gelöscht
+    DELETE = "delete"      # Lokal löschen, wenn remote gelöscht
+    ARCHIVE = "archive"   # In Archiv-Ordner verschieben

--- a/app/routers/backup.py
+++ b/app/routers/backup.py
@@ -77,6 +77,8 @@ async def trigger_backup(apple_id: str):
                 destination=cfg.get("destination", ""),
                 exclusions=cfg.get("exclusions"),
                 config_id=apple_id,
+                drive_sync_policy=cfg.get("drive_sync_policy", "delete"),
+                photos_sync_policy=cfg.get("photos_sync_policy", "keep"),
             )
             status = "success" if result["success"] else "error"
             message = result["message"]

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from app.models import AccountStatus, BackupStatus, DriveConfigMode
+from app.models import AccountStatus, BackupStatus, DriveConfigMode, SyncPolicy
 
 
 class AccountCreate(BaseModel):
@@ -33,6 +33,8 @@ class BackupConfigCreate(BaseModel):
     drive_folders_simple: list[str] | None = None
     drive_folders_advanced: str | None = None
     photos_include_family: bool = False
+    drive_sync_policy: SyncPolicy = SyncPolicy.DELETE
+    photos_sync_policy: SyncPolicy = SyncPolicy.KEEP
     exclusions: list[str] | None = None
     destination: str = ""
 
@@ -45,6 +47,8 @@ class BackupConfigResponse(BaseModel):
     drive_folders_simple: list[str] | None = None
     drive_folders_advanced: str | None = None
     photos_include_family: bool
+    drive_sync_policy: SyncPolicy = SyncPolicy.DELETE
+    photos_sync_policy: SyncPolicy = SyncPolicy.KEEP
     exclusions: list[str] | None = None
     destination: str
     last_backup_status: BackupStatus = BackupStatus.IDLE

--- a/app/templates/account_detail.html
+++ b/app/templates/account_detail.html
@@ -134,6 +134,26 @@
                                 Relative Pfade ab dem iCloud Drive Root-Verzeichnis.
                             </div>
                         </div>
+
+                        <!-- Drive Sync Policy -->
+                        <div class="mt-3 pt-3 border-top">
+                            <label for="driveSyncPolicy" class="form-label fw-semibold">
+                                <i class="bi bi-arrow-repeat me-1"></i>
+                                Remote gelöschte Dateien
+                            </label>
+                            <select class="form-select" id="driveSyncPolicy"
+                                    x-model="config.drive_sync_policy">
+                                <option value="delete">Lokal löschen</option>
+                                <option value="keep">Lokal behalten</option>
+                                <option value="archive">In Archiv verschieben</option>
+                            </select>
+                            <div class="form-text">
+                                Was passiert mit lokalen Dateien, die in iCloud Drive gelöscht wurden?
+                                <span x-show="config.drive_sync_policy === 'archive'" class="text-info">
+                                    Dateien werden nach <code>/archive/</code> verschoben.
+                                </span>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
@@ -154,6 +174,26 @@
                             </label>
                             <div class="form-text">
                                 Falls vorhanden, werden geteilte Familienfotos ebenfalls gesichert.
+                            </div>
+                        </div>
+
+                        <!-- Photos Sync Policy -->
+                        <div class="mt-3 pt-3 border-top">
+                            <label for="photosSyncPolicy" class="form-label fw-semibold">
+                                <i class="bi bi-arrow-repeat me-1"></i>
+                                Remote gelöschte Fotos
+                            </label>
+                            <select class="form-select" id="photosSyncPolicy"
+                                    x-model="config.photos_sync_policy">
+                                <option value="keep">Lokal behalten</option>
+                                <option value="delete">Lokal löschen</option>
+                                <option value="archive">In Archiv verschieben</option>
+                            </select>
+                            <div class="form-text">
+                                Was passiert mit lokalen Fotos, die aus der iCloud Mediathek gelöscht wurden?
+                                <span x-show="config.photos_sync_policy === 'archive'" class="text-info">
+                                    Fotos werden nach <code>/archive/</code> verschoben.
+                                </span>
                             </div>
                         </div>
                     </div>
@@ -280,6 +320,12 @@
                                 <div class="border-top pt-2 mt-2">
                                     <strong>Drive:</strong>
                                     <span x-text="backupStatus.stats.drive.downloaded"></span> heruntergeladen,
+                                    <template x-if="backupStatus.stats.drive.deleted">
+                                        <span><span x-text="backupStatus.stats.drive.deleted"></span> gelöscht, </span>
+                                    </template>
+                                    <template x-if="backupStatus.stats.drive.archived">
+                                        <span><span x-text="backupStatus.stats.drive.archived"></span> archiviert, </span>
+                                    </template>
                                     <span x-text="backupStatus.stats.drive.skipped"></span> übersprungen,
                                     <span x-text="backupStatus.stats.drive.errors"></span> Fehler
                                 </div>
@@ -288,6 +334,12 @@
                                 <div class="border-top pt-2 mt-2">
                                     <strong>Fotos:</strong>
                                     <span x-text="backupStatus.stats.photos.downloaded"></span> heruntergeladen,
+                                    <template x-if="backupStatus.stats.photos.deleted">
+                                        <span><span x-text="backupStatus.stats.photos.deleted"></span> gelöscht, </span>
+                                    </template>
+                                    <template x-if="backupStatus.stats.photos.archived">
+                                        <span><span x-text="backupStatus.stats.photos.archived"></span> archiviert, </span>
+                                    </template>
                                     <span x-text="backupStatus.stats.photos.skipped"></span> übersprungen,
                                     <span x-text="backupStatus.stats.photos.errors"></span> Fehler
                                 </div>
@@ -315,6 +367,8 @@ function accountConfig(appleId) {
             drive_folders_simple: [],
             drive_folders_advanced: '',
             photos_include_family: false,
+            drive_sync_policy: 'delete',
+            photos_sync_policy: 'keep',
             destination: '',
         },
         exclusionsText: '',
@@ -375,6 +429,8 @@ function accountConfig(appleId) {
                     drive_folders_simple: c.drive_folders_simple || [],
                     drive_folders_advanced: c.drive_folders_advanced || '',
                     photos_include_family: c.photos_include_family,
+                    drive_sync_policy: c.drive_sync_policy || 'delete',
+                    photos_sync_policy: c.photos_sync_policy || 'keep',
                     destination: c.destination || '',
                 };
                 const simpleFolders = c.drive_folders_simple || [];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ${BACKUP_PATH:-./backups}:/backups
       - ${CONFIG_PATH:-./config}:/config
+      - ${ARCHIVE_PATH:-./archive}:/archive
       # Synology DSM notifications (uncomment on Synology NAS)
       # - /usr/syno/bin/synodsmnotify:/usr/local/bin/synodsmnotify:ro
     environment:


### PR DESCRIPTION
…ive)

Users can now choose per-account what happens to local files when they are deleted in iCloud:

- **keep**: Local files remain untouched (default for Photos)
- **delete**: Local files are removed (default for Drive, preserves existing behavior)
- **archive**: Files are moved to a dedicated /archive mount point, preserving the folder structure

Changes:
- New SyncPolicy enum (keep/delete/archive) in models.py
- New config fields drive_sync_policy and photos_sync_policy
- New /archive Docker volume mount (ARCHIVE_PATH env var)
- Shared _apply_sync_policy() helper used by both Drive and Photos
- Photos backup now tracks remote files and reconciles local state
- Frontend dropdowns for both Drive and Photos sync policy
- Stats display shows deleted/archived counts when applicable

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc