### PR TITLE
docs: document sync policy feature and /archive volume

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -7,6 +7,7 @@ Back up your **iCloud Drive** and **iCloud Photos** automatically with a simple 
 - Multi-account support with 2FA (device push & SMS)
 - iCloud Drive backup (folder selection or manual paths)
 - iCloud Photos backup (including family library)
+- Configurable sync policy per backup type: **keep**, **delete**, or **archive** removed files
 - Scheduled backups via cron expressions
 - Password-protected web UI
 - Exclusion patterns (glob, paths)
@@ -30,6 +31,7 @@ services:
     volumes:
       - ./backups:/backups
       - ./config:/config
+      - ./archive:/archive    # for sync policy "archive"
     environment:
       - TZ=Europe/Berlin
       - AUTH_PASSWORD=my-secure-password
@@ -52,6 +54,7 @@ Open **http://localhost:8080** and log in.
 | `SECRET_KEY` | `change-me-in-production` | Secret for cookie signing. |
 | `LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
 | `SYNOLOGY_NOTIFY` | `false` | Enable Synology DSM notifications (`true`/`false`). |
+| `ARCHIVE_PATH` | `./archive` | Host path for archived files (sync policy "archive"). |
 | `TZ` | `Europe/Berlin` | Container timezone. |
 
 ## Volumes
@@ -60,12 +63,21 @@ Open **http://localhost:8080** and log in.
 |------|-------------|
 | `/backups` | Backup destination |
 | `/config` | Config file, session tokens, caches |
+| `/archive` | Archived files when sync policy is set to "archive" |
 
 ## How It Works
 
 1. **Add account** – Enter your Apple ID and app-specific password, confirm 2FA (device push or SMS)
-2. **Configure** – Select folders/photos, set exclusions, choose schedule
+2. **Configure** – Select folders/photos, set exclusions, choose schedule and sync policy
 3. **Back up** – Run manually or let the scheduler handle it
+
+### Sync Policy
+
+For each backup type (Drive / Photos) you can choose independently what happens when files are deleted in iCloud:
+
+- **Keep** – local files remain untouched (default for Photos)
+- **Delete** – local files are removed (default for Drive)
+- **Archive** – files are moved to `/archive`, preserving the folder structure
 
 Session tokens are cached so you don't need to re-authenticate on every run. 2FA tokens typically last ~2 months.
 


### PR DESCRIPTION
Update README, AGENTS and DOCKERHUB docs to cover:
- New sync policy options (keep/delete/archive) for Drive and Photos
- ARCHIVE_PATH environment variable
- /archive Docker volume mount
- Synology setup examples with archive directory
- AGENTS.md: SyncPolicy enum, _apply_sync_policy helper, reconciliation flow

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc