### PR TITLE
feat: add backup cancel button

### DIFF
--- a/app/routers/backup.py
+++ b/app/routers/backup.py
@@ -107,6 +107,15 @@ async def trigger_backup(apple_id: str):
     )
 
 
+@router.post("/cancel/{apple_id}")
+async def cancel_backup(apple_id: str):
+    """Cancel a running backup for the given account."""
+    cancelled = backup_service.request_cancel(apple_id)
+    if not cancelled:
+        raise HTTPException(status_code=400, detail="Kein laufendes Backup gefunden.")
+    return {"message": "Abbruch angefordert.", "apple_id": apple_id}
+
+
 @router.get("/status/{apple_id}")
 async def get_backup_status(apple_id: str):
     """Get current backup status for an account."""

--- a/app/templates/account_detail.html
+++ b/app/templates/account_detail.html
@@ -250,10 +250,17 @@
                             Konfiguration speichern
                         </button>
                         <button type="button" class="btn btn-success" @click="triggerBackup()"
-                                :disabled="backupRunning">
-                            <span x-show="backupRunning" class="spinner-border spinner-border-sm me-1"></span>
-                            <i class="bi bi-play-fill me-1" x-show="!backupRunning"></i>
+                                :disabled="backupRunning"
+                                x-show="!backupRunning">
+                            <i class="bi bi-play-fill me-1"></i>
                             Backup jetzt starten
+                        </button>
+                        <button type="button" class="btn btn-danger" @click="cancelBackup()"
+                                :disabled="cancelRequested"
+                                x-show="backupRunning">
+                            <i class="bi bi-x-circle me-1" x-show="!cancelRequested"></i>
+                            <span x-show="cancelRequested" class="spinner-border spinner-border-sm me-1"></span>
+                            <span x-text="cancelRequested ? 'Wird abgebrochen...' : 'Backup abbrechen'"></span>
                         </button>
                     </div>
                 </div>
@@ -378,6 +385,7 @@ function accountConfig(appleId) {
         driveFoldersLoading: false,
         saving: false,
         backupRunning: false,
+        cancelRequested: false,
         backupStatus: {},
         progress: { running: false },
         successMsg: '',
@@ -462,6 +470,7 @@ function accountConfig(appleId) {
                     this.startProgressPolling();
                 } else {
                     this.backupRunning = false;
+                    this.cancelRequested = false;
                     this.stopProgressPolling();
                 }
             } catch (e) {
@@ -568,6 +577,24 @@ function accountConfig(appleId) {
             } catch (e) {
                 this.errorMsg = 'Netzwerkfehler: ' + e.message;
                 this.backupRunning = false;
+            }
+        },
+
+        async cancelBackup() {
+            this.cancelRequested = true;
+            this.errorMsg = '';
+            try {
+                const res = await fetch(`/api/backup/cancel/${this.encodedId()}`, { method: 'POST' });
+                if (res.ok) {
+                    this.successMsg = 'Abbruch angefordert...';
+                } else {
+                    const err = await res.json();
+                    this.errorMsg = err.detail || 'Fehler beim Abbrechen.';
+                    this.cancelRequested = false;
+                }
+            } catch (e) {
+                this.errorMsg = 'Netzwerkfehler: ' + e.message;
+                this.cancelRequested = false;
             }
         },
 


### PR DESCRIPTION
Users can now abort a running backup from the web UI.

Implementation:
- threading.Event per backup run for cooperative cancellation
- _check_cancel() called in every download/iteration loop (drive walk, drive folder loop, photos mediathek, album loop)
- BackupCancelled exception bubbles up to run_backup() which logs it cleanly and reports "Abgebrochen durch Benutzer"
- POST /api/backup/cancel/{apple_id} endpoint
- Red cancel button replaces the start button while backup runs
- cancelRequested state resets automatically when backup finishes

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc