### PR TITLE
fix: remove dead _safe_dirname function that caused PhotoAsset Attrib…

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -709,11 +709,6 @@ def run_photos_backup(
     return stats
 
 
-def _safe_dirname(name: str) -> str:
-    """Create a filesystem-safe directory name."""
-    return "".join(c if c.isalnum() or c in (" ", "-", "_") else "_" for c in name).strip()
-
-
 def get_backup_storage_stats(destination: str) -> dict:
     """Scan local backup directories and return file counts and sizes.
 


### PR DESCRIPTION
…uteError

The old family album iteration code (removed in a89dc8f) passed BasePhotoAlbum objects to _safe_dirname instead of strings, causing 'PhotoAsset' object has no attribute 'isalnum' errors. The function is no longer used since shared library handling was rewritten.

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc