### PR TITLE
fix: dark mode styling for dashboard storage stat boxes

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -60,6 +60,12 @@ main {
     border-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Storage stat boxes on dashboard */
+.stat-box {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
 /* Alert transitions */
 .alert {
     transition: opacity 0.3s ease;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -60,17 +60,17 @@
                             <div class="mb-2">
                                 <div class="row g-2">
                                     <div class="col-6">
-                                        <div class="border rounded p-2 text-center bg-light">
-                                            <div class="text-muted small"><i class="bi bi-image me-1"></i>Fotos</div>
+                                        <div class="rounded p-2 text-center stat-box">
+                                            <div class="text-body-secondary small"><i class="bi bi-image me-1"></i>Fotos</div>
                                             <div class="fw-semibold" x-text="storageStats[account.apple_id].photos.count.toLocaleString('de-DE') + ' Objekte'"></div>
-                                            <div class="text-muted small" x-text="formatSize(storageStats[account.apple_id].photos.size_bytes)"></div>
+                                            <div class="text-body-secondary small" x-text="formatSize(storageStats[account.apple_id].photos.size_bytes)"></div>
                                         </div>
                                     </div>
                                     <div class="col-6">
-                                        <div class="border rounded p-2 text-center bg-light">
-                                            <div class="text-muted small"><i class="bi bi-cloud me-1"></i>Drive</div>
+                                        <div class="rounded p-2 text-center stat-box">
+                                            <div class="text-body-secondary small"><i class="bi bi-cloud me-1"></i>Drive</div>
                                             <div class="fw-semibold" x-text="storageStats[account.apple_id].drive.count.toLocaleString('de-DE') + ' Dateien'"></div>
-                                            <div class="text-muted small" x-text="formatSize(storageStats[account.apple_id].drive.size_bytes)"></div>
+                                            <div class="text-body-secondary small" x-text="formatSize(storageStats[account.apple_id].drive.size_bytes)"></div>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Replace bg-light (renders white in dark theme) with custom stat-box class using subtle rgba backgrounds. Also use text-body-secondary instead of text-muted for better theme compatibility.

https://claude.ai/code/session_019dTEZLdQRYNCKuUEv8PXqc