### PR TITLE
Fix shared-folder fallback by passing nested share context

### DIFF
--- a/tests/test_shared_folder_download.py
+++ b/tests/test_shared_folder_download.py
@@ -1,0 +1,67 @@
+"""Tests for shared-folder download fallbacks."""
+
+from types import SimpleNamespace
+
+from app.services.backup_service import _download_with_share_context
+
+
+class _DummyResponse:
+    def __init__(self, ok=True, payload=None):
+        self.ok = ok
+        self.reason = "OK" if ok else "Not Found"
+        self.status_code = 200 if ok else 404
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class _DummySession:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, params=None, **kwargs):
+        self.calls.append((url, params, kwargs))
+        if url.endswith("/download/by_id"):
+            return _DummyResponse(
+                ok=True,
+                payload={"data_token": {"url": "https://download.example/file"}},
+            )
+        return _DummyResponse(ok=True)
+
+
+def test_download_with_share_context_flattens_nested_share_id():
+    session = _DummySession()
+    connection = SimpleNamespace(
+        params={"base": "1"},
+        _document_root="https://docws.example",
+        session=session,
+    )
+
+    share_id = {
+        "shareName": "SHARE",
+        "recordName": "RECORD",
+        "zoneID": {
+            "zoneName": "com.apple.CloudDocs",
+            "ownerRecordName": "_owner",
+        },
+    }
+
+    _download_with_share_context(
+        connection,
+        docwsid="DOC-1",
+        zone="com.apple.CloudDocs",
+        share_id=share_id,
+        stream=True,
+    )
+
+    _, first_params, _ = session.calls[0]
+    assert first_params["document_id"] == "DOC-1"
+    assert first_params["shareName"] == "SHARE"
+    assert first_params["recordName"] == "RECORD"
+    assert first_params["zoneID.zoneName"] == "com.apple.CloudDocs"
+    assert first_params["zoneID.ownerRecordName"] == "_owner"
+
+    # Compatibility aliases for services that expect flattened names
+    assert first_params["zoneName"] == "com.apple.CloudDocs"
+    assert first_params["ownerRecordName"] == "_owner"


### PR DESCRIPTION
## Summary
- enhance shared-folder fallback query construction in `app/services/backup_service.py`
- recursively flatten nested `shareID` structures (including `zoneID.*`) so requests include complete shared-folder context
- add compatibility aliases for nested keys (`zoneName`, `ownerRecordName`) to support backend variants
- add focused unit test `tests/test_shared_folder_download.py` to verify generated request parameters

## Why
Downloads for files inside shared folders with special characters can return `404 WSObjectNotFound` when the `/download/by_id` call lacks full share metadata. The existing code only forwarded top-level scalar fields and dropped nested fields like `zoneID.zoneName`/`zoneID.ownerRecordName`.

## Validation
- static inspection of fallback flow in `_open_drive_node()` and `_download_with_share_context()`
- new test verifies parameter payload includes nested and alias keys

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6994e2b23400832e82c2c100dd27029c)