### PR TITLE
Add CloudKit-based download fallback for shared-with-you folders

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -4,6 +4,7 @@ import gc
 import json
 import logging
 import os
+import re
 import shutil
 import threading
 from datetime import datetime
@@ -390,6 +391,148 @@ def _download_with_share_context(connection, docwsid, zone, share_id, **kwargs):
     raise KeyError("No data_token or package_token in response")
 
 
+# ---------------------------------------------------------------------------
+# CloudKit-based download for "shared with you" folders
+# ---------------------------------------------------------------------------
+
+def _derive_ckdatabase_url(service_root: str) -> str | None:
+    """Derive the ckdatabasews base URL from a drivews/docws service root.
+
+    The iCloud web-service URLs follow the pattern
+    ``https://p{N}-{service}.icloud.com:443``.  We replace the service name
+    with ``ckdatabasews`` to obtain the CloudKit Database Web Service URL.
+    """
+    m = re.match(r"(https://p\d+-)\w+(\.\w+\.com(?::\d+)?)", service_root)
+    if m:
+        return f"{m.group(1)}ckdatabasews{m.group(2)}"
+    return None
+
+
+def _download_via_cloudkit(connection, docwsid: str, share_id: dict, **kwargs):
+    """Download a file from a *shared-with-you* folder via the CloudKit API.
+
+    The standard ``docws`` download endpoint only works for files in the
+    user's own iCloud Drive.  Files that belong to another user (shared
+    folder whose owner is someone else) must be downloaded through the
+    **CloudKit Database Web Service** (``ckdatabasews``).
+
+    Steps:
+      1. Derive the ``ckdatabasews`` URL from the Drive service root.
+      2. POST a ``records/lookup`` request to the **shared** database
+         using the file's record name and the owner's zone ID.
+      3. Extract the asset download URL from the response.
+      4. Stream the file content.
+    """
+    from pyicloud.exceptions import PyiCloudAPIResponseException
+
+    ck_base = _derive_ckdatabase_url(connection._service_root)
+    if not ck_base:
+        raise RuntimeError("Could not derive ckdatabasews URL")
+
+    zone_id = share_id.get("zoneID", {})
+    if not zone_id.get("ownerRecordName"):
+        raise ValueError("shareID has no ownerRecordName")
+
+    # Build the endpoint URL for the shared CloudKit database.
+    # Container for iCloud Drive is "com.apple.clouddocs".
+    ck_endpoint = (
+        f"{ck_base}/database/1/com.apple.clouddocs/production/private"
+    )
+    lookup_url = f"{ck_endpoint}/records/lookup"
+
+    # Try the docwsid (UUID) as the record name.
+    lookup_body = {
+        "records": [{"recordName": docwsid}],
+        "zoneID": zone_id,
+    }
+
+    log.debug(
+        "CloudKit records/lookup: url=%s, body=%s",
+        lookup_url,
+        json.dumps(lookup_body),
+    )
+
+    response = connection.session.post(
+        lookup_url,
+        params=connection.params,
+        json=lookup_body,
+    )
+
+    if not response.ok:
+        log.debug(
+            "CloudKit lookup fehlgeschlagen (private): %s %s",
+            response.status_code,
+            response.text[:300] if hasattr(response, 'text') else response.reason,
+        )
+        # Try the shared database as well
+        ck_endpoint_shared = (
+            f"{ck_base}/database/1/com.apple.clouddocs/production/shared"
+        )
+        lookup_url_shared = f"{ck_endpoint_shared}/records/lookup"
+        log.debug("Versuche CloudKit shared database: %s", lookup_url_shared)
+        response = connection.session.post(
+            lookup_url_shared,
+            params=connection.params,
+            json=lookup_body,
+        )
+        if not response.ok:
+            log.debug(
+                "CloudKit lookup fehlgeschlagen (shared): %s %s",
+                response.status_code,
+                response.text[:300] if hasattr(response, 'text') else response.reason,
+            )
+            raise PyiCloudAPIResponseException(response.reason, response.status_code)
+
+    result = response.json()
+    records = result.get("records", [])
+    if not records:
+        raise KeyError("CloudKit lookup returned no records")
+
+    record = records[0]
+
+    # Check for server errors in the record itself
+    if "serverErrorCode" in record:
+        log.debug(
+            "CloudKit record error: %s - %s",
+            record.get("serverErrorCode"),
+            record.get("reason", ""),
+        )
+        raise PyiCloudAPIResponseException(
+            record.get("reason", record["serverErrorCode"]),
+            404 if record["serverErrorCode"] == "NOT_FOUND" else 500,
+        )
+
+    # Extract download URL from the record's fields.
+    # iCloud Drive file records store the binary content as a CKAsset.
+    # Typical field names include "fileContent" or a reference field.
+    fields = record.get("fields", {})
+    log.debug(
+        "CloudKit record fields: %s",
+        list(fields.keys()),
+    )
+
+    # Look for asset fields that contain a download URL
+    download_url = None
+    for field_name, field_data in fields.items():
+        if isinstance(field_data, dict):
+            value = field_data.get("value", {})
+            if isinstance(value, dict) and value.get("downloadURL"):
+                download_url = value["downloadURL"]
+                log.debug(
+                    "CloudKit download URL gefunden in Feld '%s': %s",
+                    field_name,
+                    download_url[:80] + "..." if len(download_url) > 80 else download_url,
+                )
+                break
+
+    if not download_url:
+        log.debug("CloudKit record hat keine downloadURL. Vollständiger Record: %s",
+                  json.dumps(record, default=str)[:500])
+        raise KeyError("No downloadURL found in CloudKit record fields")
+
+    return connection.session.get(download_url, params=connection.params, **kwargs)
+
+
 def _open_drive_node(node, rel_path: str, **kwargs):
     """Open a drive node file with fallback on 404 errors.
 
@@ -400,8 +543,9 @@ def _open_drive_node(node, rel_path: str, **kwargs):
     in ``drivewsid``) because the standard download call is missing the
     ``shareID`` context that Apple's API needs to locate the document.
 
-    On any 404 we attempt four fallbacks:
+    On any 404 we attempt five fallbacks:
 
+    0. For shared-folder files: retry with the owner-qualified zone.
     1. Re-fetch the node metadata via ``retrieveItemDetailsInFolders``
        (POST with JSON body — immune to URL-encoding issues, includes
        ``shareID`` for shared folders) and retry with the fresh
@@ -410,6 +554,9 @@ def _open_drive_node(node, rel_path: str, **kwargs):
        fields included as query parameters.
     3. Pass the ``drivewsid`` as ``document_id``.
     4. Extract the raw UUID from ``drivewsid`` and try that.
+    5. For shared-with-you folders: download via the CloudKit Database
+       Web Service (``ckdatabasews``) which can access files in another
+       user's shared zone.
     """
     try:
         return node.open(**kwargs)
@@ -533,6 +680,29 @@ def _open_drive_node(node, rel_path: str, **kwargs):
                     return node.connection.get_file(raw_id, zone=download_zone, **kwargs)
                 except Exception:
                     log.debug("Fallback 4 (raw ID) fehlgeschlagen für %s", rel_path)
+
+        # Fallback 5 (CloudKit): for shared-with-you folders the docws
+        # download API cannot resolve the file at all because it lives in
+        # another user's zone.  Use the CloudKit Database Web Service
+        # (ckdatabasews) to look up the record and obtain a download URL.
+        if is_shared and share_id:
+            for candidate_id in candidates or [docwsid]:
+                try:
+                    log.debug(
+                        "Versuche CloudKit-Download für '%s' (record=%s)",
+                        rel_path,
+                        candidate_id,
+                    )
+                    return _download_via_cloudkit(
+                        node.connection, candidate_id, share_id, **kwargs,
+                    )
+                except Exception as ck_exc:
+                    log.debug(
+                        "Fallback 5 (CloudKit) fehlgeschlagen für %s (record=%s): %s",
+                        rel_path,
+                        candidate_id,
+                        ck_exc,
+                    )
 
         raise first_exc
 

--- a/tests/test_shared_folder_download.py
+++ b/tests/test_shared_folder_download.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 from app.services.backup_service import (
     _candidate_document_ids,
+    _derive_ckdatabase_url,
+    _download_via_cloudkit,
     _download_with_share_context,
     _shared_zone,
 )
@@ -177,3 +179,103 @@ def test_download_with_share_context_uses_owner_zone_in_url():
     url, _, _ = session.calls[0]
     assert "com.apple.CloudDocs:_owner123" in url
     assert url == "https://docws.example/ws/com.apple.CloudDocs:_owner123/download/by_id"
+
+
+# ---- _derive_ckdatabase_url tests ----
+
+def test_derive_ckdatabase_url_from_drivews():
+    url = _derive_ckdatabase_url("https://p171-drivews.icloud.com:443")
+    assert url == "https://p171-ckdatabasews.icloud.com:443"
+
+
+def test_derive_ckdatabase_url_from_docws():
+    url = _derive_ckdatabase_url("https://p42-docws.icloud.com:443")
+    assert url == "https://p42-ckdatabasews.icloud.com:443"
+
+
+def test_derive_ckdatabase_url_no_port():
+    url = _derive_ckdatabase_url("https://p1-drivews.icloud.com")
+    assert url == "https://p1-ckdatabasews.icloud.com"
+
+
+def test_derive_ckdatabase_url_invalid():
+    assert _derive_ckdatabase_url("http://example.com") is None
+
+
+# ---- _download_via_cloudkit tests ----
+
+class _CKSession:
+    """Session mock that simulates CloudKit records/lookup responses."""
+
+    def __init__(self, lookup_response=None, download_response=None):
+        self.calls = []
+        self._lookup_response = lookup_response
+        self._download_response = download_response or _DummyResponse(ok=True)
+
+    def post(self, url, params=None, json=None, **kwargs):
+        self.calls.append(("POST", url, params, json))
+        if self._lookup_response:
+            return self._lookup_response
+        return _DummyResponse(ok=True, payload={"records": []})
+
+    def get(self, url, params=None, **kwargs):
+        self.calls.append(("GET", url, params, kwargs))
+        return self._download_response
+
+
+def test_cloudkit_download_calls_records_lookup():
+    """CloudKit download should POST to records/lookup with correct zone."""
+    ck_record = {
+        "recordName": "DOC-UUID",
+        "fields": {
+            "fileContent": {
+                "value": {"downloadURL": "https://cvws.example/download/file123"}
+            }
+        },
+    }
+    session = _CKSession(
+        lookup_response=_DummyResponse(ok=True, payload={"records": [ck_record]}),
+        download_response=_DummyResponse(ok=True),
+    )
+    connection = SimpleNamespace(
+        params={"dsid": "123"},
+        _service_root="https://p171-drivews.icloud.com:443",
+        session=session,
+    )
+    share_id = {
+        "zoneID": {
+            "zoneName": "com.apple.CloudDocs",
+            "ownerRecordName": "_owner999",
+        },
+    }
+
+    _download_via_cloudkit(connection, "DOC-UUID", share_id, stream=True)
+
+    # First call: POST to records/lookup
+    method, url, _, body = session.calls[0]
+    assert method == "POST"
+    assert "ckdatabasews" in url
+    assert "/records/lookup" in url
+    assert body["records"][0]["recordName"] == "DOC-UUID"
+    assert body["zoneID"]["ownerRecordName"] == "_owner999"
+
+    # Second call: GET the download URL
+    method2, url2, _, _ = session.calls[1]
+    assert method2 == "GET"
+    assert url2 == "https://cvws.example/download/file123"
+
+
+def test_cloudkit_download_no_owner_raises():
+    """CloudKit download should raise if shareID has no ownerRecordName."""
+    import pytest
+
+    session = _CKSession()
+    connection = SimpleNamespace(
+        params={},
+        _service_root="https://p1-drivews.icloud.com:443",
+        session=session,
+    )
+    share_id = {"zoneID": {"zoneName": "com.apple.CloudDocs"}}
+
+    with pytest.raises(ValueError, match="ownerRecordName"):
+        _download_via_cloudkit(connection, "DOC-1", share_id)


### PR DESCRIPTION
The docws download/by_id endpoint only works for files in the user's own iCloud Drive. Files in folders shared BY another user ("shared with you") live in the owner's CloudKit zone and cannot be resolved by the docws API at all - regardless of zone or document ID used.

Add Fallback 5: use the CloudKit Database Web Service (ckdatabasews) to perform a records/lookup in the owner's shared zone, extract the asset download URL from the response, and stream the file content.

New helpers:
- _derive_ckdatabase_url(): derives the ckdatabasews URL from the drivews service root
- _download_via_cloudkit(): performs the full CloudKit lookup and download flow, trying both private and shared databases

This specifically addresses the #Eingang shared folder issue where the folder is owned by a different Apple ID.

https://claude.ai/code/session_01E9zKU7vjJzhYnw9LfYDSeC