### PR TITLE
Fix CloudKit fallback: use correct attribute name service_root

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -425,7 +425,8 @@ def _download_via_cloudkit(connection, docwsid: str, share_id: dict, **kwargs):
     """
     from pyicloud.exceptions import PyiCloudAPIResponseException
 
-    ck_base = _derive_ckdatabase_url(connection._service_root)
+    # DriveService stores the drivews URL as .service_root (public attribute)
+    ck_base = _derive_ckdatabase_url(connection.service_root)
     if not ck_base:
         raise RuntimeError("Could not derive ckdatabasews URL")
 

--- a/tests/test_shared_folder_download.py
+++ b/tests/test_shared_folder_download.py
@@ -239,7 +239,7 @@ def test_cloudkit_download_calls_records_lookup():
     )
     connection = SimpleNamespace(
         params={"dsid": "123"},
-        _service_root="https://p171-drivews.icloud.com:443",
+        service_root="https://p171-drivews.icloud.com:443",
         session=session,
     )
     share_id = {
@@ -272,7 +272,7 @@ def test_cloudkit_download_no_owner_raises():
     session = _CKSession()
     connection = SimpleNamespace(
         params={},
-        _service_root="https://p1-drivews.icloud.com:443",
+        service_root="https://p1-drivews.icloud.com:443",
         session=session,
     )
     share_id = {"zoneID": {"zoneName": "com.apple.CloudDocs"}}


### PR DESCRIPTION
DriveService exposes the drivews URL as .service_root (public), not ._service_root. The AttributeError prevented the CloudKit fallback from executing.

https://claude.ai/code/session_01E9zKU7vjJzhYnw9LfYDSeC