### PR TITLE
Fix DSM notifications by setting LD_LIBRARY_PATH for synodsmnotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ services:
          - /volume1/docker/icloud-backup/config:/config
          - /volume1/docker/icloud-backup/archive:/archive
          - /usr/syno/bin/synodsmnotify:/usr/local/bin/synodsmnotify:ro
+         - /usr/lib:/usr/syno/lib:ro
        environment:
          - TZ=Europe/Berlin
          - AUTH_PASSWORD=my-secure-password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ${ARCHIVE_PATH:-./archive}:/archive
       # Synology DSM notifications (uncomment on Synology NAS)
       # - /usr/syno/bin/synodsmnotify:/usr/local/bin/synodsmnotify:ro
+      # - /usr/lib:/usr/syno/lib:ro
     environment:
       - TZ=${TZ:-Europe/Berlin}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}


### PR DESCRIPTION
## Summary
This PR fixes DSM notifications on Synology NAS by properly configuring the library path for the `synodsmnotify` binary. The binary requires access to Synology's shared libraries to function correctly.

## Key Changes
- Added `os` import to support environment variable manipulation
- Introduced `_SYNO_LIB_DIR` constant pointing to `/usr/syno/lib`
- Set `LD_LIBRARY_PATH` environment variable when executing `synodsmnotify` to include the Synology library directory
- Enhanced error handling to detect and provide helpful feedback when shared libraries are missing (exit code 127 with "shared librar" in stderr)
- Updated warning messages to instruct users to mount both the binary and library volumes in docker-compose
- Updated documentation (README.md and docker-compose.yml) to include the required `/usr/lib:/usr/syno/lib:ro` volume mount

## Implementation Details
- The subprocess call now passes a modified environment dictionary that preserves existing `LD_LIBRARY_PATH` entries while prepending the Synology library directory
- Error handling distinguishes between missing shared libraries (exit code 127) and other failures, providing specific guidance for the library issue
- All changes are backward compatible and only affect DSM notification functionality

https://claude.ai/code/session_015GLV9YVuDdRxALv8vuvvEm