### PR TITLE
Compare shareID ownerRecordName with current user to distinguish own …

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -665,13 +665,15 @@ def sync_drive_folder(
     if isinstance(share_id, dict):
         owner = share_id.get("zoneID", {}).get("ownerRecordName", "")
         if owner:
-            log.warning(
-                "Überspringe '%s': Ordner gehört einem anderen Benutzer "
-                "(Fremdfreigabe) und kann nicht über die iCloud-API "
-                "heruntergeladen werden.",
-                folder_name,
-            )
-            return stats
+            user_record = icloud_service._get_user_record_name(api)
+            if not user_record or owner != user_record:
+                log.warning(
+                    "Überspringe '%s': Ordner gehört einem anderen Benutzer "
+                    "(Fremdfreigabe) und kann nicht über die iCloud-API "
+                    "heruntergeladen werden.",
+                    folder_name,
+                )
+                return stats
 
     dest = destination_path / folder_name
     dest.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
…vs foreign shares

Previously all folders with a shareID were flagged as shared_not_owned, including folders the user owns and has shared with others. Now we:

1. Derive the user's CloudKit ownerRecordName from dsInfo.aDsID (anonymous DSID → "_<hex-without-dashes>" format)
2. Compare the shareID's ownerRecordName against the user's own record
3. Only flag folders where the owner differs (= foreign shares)

If the user's record name cannot be determined (aDsID/altDSID not in dsInfo), we fall back to the safe default of flagging all shared folders. Debug logging dumps dsInfo keys to aid troubleshooting.

https://claude.ai/code/session_01E9zKU7vjJzhYnw9LfYDSeC