### PR TITLE
Replace broken dsInfo-based user detection with majority-vote from sh…

### DIFF
--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -665,7 +665,7 @@ def sync_drive_folder(
     if isinstance(share_id, dict):
         owner = share_id.get("zoneID", {}).get("ownerRecordName", "")
         if owner:
-            user_record = icloud_service._get_user_record_name(api)
+            user_record = icloud_service.get_user_record(apple_id)
             if not user_record or owner != user_record:
                 log.warning(
                     "Überspringe '%s': Ordner gehört einem anderen Benutzer "


### PR DESCRIPTION
…ared folders

The altDSID/aDsID from dsInfo is a 40-hex-char identifier that does NOT match CloudKit's 32-hex-char ownerRecordName — they are completely different Apple identifiers.

New approach: when listing Drive folders, collect all ownerRecordName values from shared children and use majority-vote to determine which one belongs to the current user (users typically have more of their own shared folders than folders shared with them).

The detected record is cached in _user_records[apple_id] so the backup service can reuse it without re-querying.

https://claude.ai/code/session_01E9zKU7vjJzhYnw9LfYDSeC