### PR TITLE
Refactor Dockerfile: Move setup steps before build arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM python:3.12-slim
 
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app/ ./app/
+
 ARG APP_VERSION=dev
 ARG APP_COMMIT=unknown
 ARG APP_BUILD_DATE=unknown
@@ -11,17 +22,6 @@ LABEL org.opencontainers.image.version=$APP_VERSION \
 ENV APP_VERSION=$APP_VERSION \
     APP_COMMIT=$APP_COMMIT \
     APP_BUILD_DATE=$APP_BUILD_DATE
-
-WORKDIR /app
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY app/ ./app/
 
 VOLUME ["/backups", "/config", "/archive"]
 


### PR DESCRIPTION
## Summary
Reorganized the Dockerfile to move application setup steps (working directory, dependencies, and source code) before the build argument definitions. This improves the logical flow and ensures the application is prepared before environment variables are set.

## Key Changes
- Moved `WORKDIR /app` to the beginning of the Dockerfile (after base image)
- Moved system dependency installation (`apt-get update` and `curl` install) before build arguments
- Moved `requirements.txt` copy and pip install before build arguments
- Moved application source code copy (`COPY app/`) before build arguments
- Kept build arguments (`ARG APP_VERSION`, `ARG APP_COMMIT`, `ARG APP_BUILD_DATE`) and their corresponding environment variable assignments together in their new position
- Preserved all other configuration (VOLUME, EXPOSE, etc.) at the end

## Implementation Details
This refactoring improves the Dockerfile structure by grouping related operations together and establishing a clearer separation between:
1. Application setup and dependencies (early in the build)
2. Build metadata and environment configuration (middle section)
3. Runtime configuration (end of the file)

The functional behavior remains unchanged; this is purely a reorganization for better maintainability and clarity.

https://claude.ai/code/session_01R24Xf8M9VcKoGKTXDdzLMA