### PR TITLE
Sort shared-not-owned folders to the bottom of the Drive list

### DIFF
--- a/app/services/icloud_service.py
+++ b/app/services/icloud_service.py
@@ -369,7 +369,7 @@ def get_drive_folders(apple_id: str) -> list[dict]:
     except Exception as exc:
         log.error("Fehler beim Abrufen der Drive-Ordner für %s: %s", apple_id, exc)
 
-    return sorted(folders, key=lambda f: f["name"].lower())
+    return sorted(folders, key=lambda f: (f["shared_not_owned"], f["name"].lower()))
 
 
 def get_photo_libraries(apple_id: str) -> list[dict]:


### PR DESCRIPTION
Eigene Ordner erscheinen jetzt zuerst (alphabetisch), danach Fremdfreigaben (ebenfalls alphabetisch).

https://claude.ai/code/session_01E9zKU7vjJzhYnw9LfYDSeC