### PR TITLE
fix: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Restore cached version
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .pyicloud-version
           key: pyicloud-version-${{ steps.pypi.outputs.version }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.compare.outputs.changed == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -136,7 +136,7 @@ jobs:
 
       - name: Update cache
         if: steps.compare.outputs.changed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .pyicloud-version
           key: pyicloud-version-${{ steps.pypi.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,23 +17,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -46,7 +46,7 @@ jobs:
         run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -78,7 +78,7 @@ jobs:
           } > DOCKERHUB_FULL.md
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Resolves Node.js 20 deprecation warnings by bumping:
- actions/checkout v4 → v5
- actions/cache v4 → v5
- docker/setup-qemu-action v3 → v4
- docker/setup-buildx-action v3 → v4
- docker/login-action v3 → v4
- docker/metadata-action v5 → v6
- docker/build-push-action v6 → v7
- peter-evans/dockerhub-description v4 → v5

https://claude.ai/code/session_01TR8KnDyRgGgdavDhcVCbgP