### PR TITLE
Move notification settings to web UI and add iCloud storage caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **iCloud-Speicherinfo wird gecached** – Die Aufteilung der iCloud-Nutzung (Fotos, Drive, Backups, Mail, …) wird jetzt automatisch nach jedem Backup aktualisiert und persistent unter `/config/.icloud-storage-cache-<account>.json` gespeichert. Das Dashboard lädt die Anzeige damit ohne erneuten API-Call an Apple. Mit `GET /api/accounts/<id>/icloud-storage?refresh=true` lässt sich die Anzeige manuell auffrischen.
+- **Benachrichtigungen werden in der Web-UI konfiguriert** – DSM- und Pushover-Einstellungen werden nicht mehr über `DSM_NOTIFY` / `PUSHOVER_*` in `docker-compose.yml` gesetzt, sondern über den neuen Menüpunkt **Einstellungen**. Die Konfiguration landet im bestehenden `/config/config.yaml`. Secrets werden beim Auslesen der API nicht mehr zurückgegeben und können durch leere Eingabe erhalten bleiben.
+
+### Removed
+- Environment-Variablen `DSM_NOTIFY`, `PUSHOVER_ENABLED`, `PUSHOVER_API_TOKEN`, `PUSHOVER_USER_KEY`, `PUSHOVER_DEVICES` sind nicht mehr wirksam. Werte aus bestehenden `docker-compose.yml` werden ignoriert – bitte einmalig in der Web-UI setzen.
+
 ## [0.9.16] - 2026-04-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.17] - 2026-04-19
+
 ### Changed
 - **iCloud-Speicherinfo wird gecached** – Die Aufteilung der iCloud-Nutzung (Fotos, Drive, Backups, Mail, …) wird jetzt automatisch nach jedem Backup aktualisiert und persistent unter `/config/.icloud-storage-cache-<account>.json` gespeichert. Das Dashboard lädt die Anzeige damit ohne erneuten API-Call an Apple. Mit `GET /api/accounts/<id>/icloud-storage?refresh=true` lässt sich die Anzeige manuell auffrischen.
 - **Benachrichtigungen werden in der Web-UI konfiguriert** – DSM- und Pushover-Einstellungen werden nicht mehr über `DSM_NOTIFY` / `PUSHOVER_*` in `docker-compose.yml` gesetzt, sondern über den neuen Menüpunkt **Einstellungen**. Die Konfiguration landet im bestehenden `/config/config.yaml`. Secrets werden beim Auslesen der API nicht mehr zurückgegeben und können durch leere Eingabe erhalten bleiben.
+
+### Added
+- Unit-Tests für den neuen Speicher-Cache (`tests/test_storage_cache.py`) und die Benachrichtigungs-API (`tests/test_notifications_settings.py`).
 
 ### Removed
 - Environment-Variablen `DSM_NOTIFY`, `PUSHOVER_ENABLED`, `PUSHOVER_API_TOKEN`, `PUSHOVER_USER_KEY`, `PUSHOVER_DEVICES` sind nicht mehr wirksam. Werte aus bestehenden `docker-compose.yml` werden ignoriert – bitte einmalig in der Web-UI setzen.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ A Docker-based backup service for **iCloud Drive**, **iCloud Photos**, **iCloud 
 - **Exclusions** – Flexible exclusion patterns (glob patterns, paths)
 - **Scheduled Backups** – Configurable via cron expressions
 - **2FA Support** – Two-factor authentication directly through the web UI (device push & SMS)
-- **Pushover Notifications** – Push notifications for backup errors and expiring tokens via [Pushover](https://pushover.net)
-- **Synology Notifications** – Optional notifications via `synodsmnotify` on Synology NAS
+- **Pushover Notifications** – Push notifications for backup errors and expiring tokens via [Pushover](https://pushover.net), configurable in the web UI
+- **Synology Notifications** – Optional notifications via `synodsmnotify` on Synology NAS, configurable in the web UI
+- **Cached iCloud Storage** – Storage breakdown is refreshed automatically after every backup and cached on disk
 - **Password Protection** – Web UI secured with password authentication
 - **Dark Mode UI** – Modern, responsive web interface
 - **Etag Caching** – Only changed folders are re-scanned
@@ -75,12 +76,11 @@ Zusätzlich wird die Version in der Web-UI im Footer angezeigt.
 | `ARCHIVE_PATH` | `./archive` | Host path for archived files (used when sync policy is set to "archive") |
 | `CONFIG_PATH` | `./config` | Host path for configuration & sessions |
 | `LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `DSM_NOTIFY` | `false` | Enable Synology DSM notifications via `synodsmnotify` (`true`/`false`) |
-| `PUSHOVER_ENABLED` | `false` | Enable [Pushover](https://pushover.net) push notifications (`true`/`false`) |
-| `PUSHOVER_API_TOKEN` | – | Pushover application API token |
-| `PUSHOVER_USER_KEY` | – | Pushover user key |
-| `PUSHOVER_DEVICES` | *(all)* | Comma-separated device names to notify (empty = all devices) |
 | `TZ` | `Europe/Berlin` | Timezone |
+
+> Notification settings (DSM and Pushover) are configured in the web UI under
+> **Einstellungen** and stored in `/config/config.yaml`. They are no longer
+> set via environment variables.
 
 ### Volumes
 
@@ -111,11 +111,8 @@ services:
     environment:
       - TZ=${TZ:-Europe/Berlin}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - DSM_NOTIFY=${DSM_NOTIFY:-false}
-      # - PUSHOVER_ENABLED=true
-      # - PUSHOVER_API_TOKEN=your-app-token
-      # - PUSHOVER_USER_KEY=your-user-key
-      # - PUSHOVER_DEVICES=                    # optional: comma-separated device names
+      # Notifications (DSM / Pushover) are configured in the web UI
+      # under "Einstellungen" and stored in /config/config.yaml.
       # - AUTH_PASSWORD=my-secure-password
       # - SECRET_KEY=...  # Optional; falls back to AUTH_PASSWORD if not set
 ```
@@ -186,8 +183,11 @@ services:
        environment:
          - TZ=Europe/Berlin
          - AUTH_PASSWORD=my-secure-password
-         - DSM_NOTIFY=true
    ```
+
+   > To enable DSM notifications, open the web UI → **Einstellungen** and
+   > toggle "DSM-Benachrichtigungen aktivieren". The mounts above
+   > (`synodsmnotify` + `/usr/lib`) are still required.
 
 5. **Start the project** → Container Manager builds and starts the container
 

--- a/app/config.py
+++ b/app/config.py
@@ -15,11 +15,6 @@ class Settings(BaseSettings):
     archive_path: Path = Path("/archive")
     cookie_directory: Path = Path("/config/sessions")
     log_level: str = "INFO"
-    dsm_notify: bool = False
-    pushover_enabled: bool = False
-    pushover_api_token: str = ""
-    pushover_user_key: str = ""
-    pushover_devices: str = ""
 
     model_config = {"env_prefix": ""}
 

--- a/app/config_store.py
+++ b/app/config_store.py
@@ -103,6 +103,16 @@ def _default_schedule() -> dict:
     }
 
 
+def _default_notifications() -> dict:
+    return {
+        "dsm_notify": False,
+        "pushover_enabled": False,
+        "pushover_api_token": "",
+        "pushover_user_key": "",
+        "pushover_devices": "",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Public API – accounts
 # ---------------------------------------------------------------------------
@@ -310,6 +320,36 @@ def save_schedule(enabled: bool, cron: str) -> dict:
         data["schedule"] = {"enabled": enabled, "cron": cron}
         _write(data)
     return data["schedule"]
+
+
+# ---------------------------------------------------------------------------
+# Public API – notification settings
+# ---------------------------------------------------------------------------
+
+def get_notifications() -> dict:
+    """Return the global notification settings, applying defaults for missing keys."""
+    with _lock:
+        data = _read()
+    stored = data.get("notifications") or {}
+    merged = _default_notifications()
+    merged.update({k: v for k, v in stored.items() if k in merged})
+    return merged
+
+
+def save_notifications(settings_dict: dict) -> dict:
+    """Persist the global notification settings."""
+    defaults = _default_notifications()
+    clean = {k: settings_dict.get(k, defaults[k]) for k in defaults}
+    # Coerce booleans so YAML doesn't end up with "true"/"false" strings.
+    clean["dsm_notify"] = bool(clean["dsm_notify"])
+    clean["pushover_enabled"] = bool(clean["pushover_enabled"])
+    for key in ("pushover_api_token", "pushover_user_key", "pushover_devices"):
+        clean[key] = str(clean.get(key) or "")
+    with _lock:
+        data = _read()
+        data["notifications"] = clean
+        _write(data)
+    return clean
 
 
 def list_configured_accounts() -> list[dict]:

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from fastapi.templating import Jinja2Templates
 from app.auth import AuthMiddleware, _COOKIE_NAME, create_session_cookie
 from app import config_store
 from app.config import settings
-from app.routers import accounts, backup
+from app.routers import accounts, backup, settings as settings_router
 from app.services.log_handler import log_buffer
 from app.services.scheduler import start_scheduler, stop_scheduler, sync_scheduled_jobs
 
@@ -112,6 +112,7 @@ app.add_middleware(AuthMiddleware)
 # API routers
 app.include_router(accounts.router)
 app.include_router(backup.router)
+app.include_router(settings_router.router)
 
 
 # ---------------------------------------------------------------------------
@@ -198,3 +199,8 @@ async def account_detail(request: Request, apple_id: str):
 @app.get("/logs")
 async def logs_page(request: Request):
     return templates.TemplateResponse(name="logs.html", request=request, context={"build": _build_info()})
+
+
+@app.get("/settings")
+async def settings_page(request: Request):
+    return templates.TemplateResponse(name="settings.html", request=request, context={"build": _build_info()})

--- a/app/routers/accounts.py
+++ b/app/routers/accounts.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException
 
 from app import config_store
 from app.schemas import AccountCreate, AccountResponse, ReconnectRequest, SmsSendRequest, TwoFactorSubmit, TwoStepSubmit
-from app.services import icloud_service
+from app.services import icloud_service, storage_cache
 from app.services.notification import notify_token_expired
 
 log = logging.getLogger("icloud-backup")
@@ -203,15 +203,32 @@ async def check_connection(apple_id: str):
 
 
 @router.get("/{apple_id}/icloud-storage")
-async def get_icloud_storage(apple_id: str):
-    """Return iCloud storage quota and per-media usage."""
+async def get_icloud_storage(apple_id: str, refresh: bool = False):
+    """Return iCloud storage quota and per-media usage.
+
+    Reads from the on-disk cache by default (populated after every backup).
+    Set ``?refresh=true`` to force a fresh fetch from Apple.
+    """
     account = config_store.get_account(apple_id)
     if account is None:
         raise HTTPException(status_code=404, detail="Account nicht gefunden.")
-    if account["status"] != "authenticated":
-        raise HTTPException(status_code=400, detail="Account nicht authentifiziert.")
 
-    data = icloud_service.get_storage_usage(apple_id)
+    if refresh:
+        if account["status"] != "authenticated":
+            raise HTTPException(status_code=400, detail="Account nicht authentifiziert.")
+        data = storage_cache.refresh(apple_id)
+        if data is None:
+            raise HTTPException(status_code=503, detail="Speicherinfo nicht verfügbar.")
+        return data
+
+    cached = storage_cache.load_cache(apple_id)
+    if cached is not None:
+        return cached
+
+    # No cache yet – try a one-shot fetch so the UI has something to show.
+    if account["status"] != "authenticated":
+        raise HTTPException(status_code=503, detail="Speicherinfo nicht verfügbar.")
+    data = storage_cache.refresh(apple_id)
     if data is None:
         raise HTTPException(status_code=503, detail="Speicherinfo nicht verfügbar.")
     return data
@@ -223,6 +240,7 @@ async def delete_account(apple_id: str):
         raise HTTPException(status_code=404, detail="Account nicht gefunden.")
 
     icloud_service.disconnect(apple_id)
+    storage_cache.delete_cache(apple_id)
     return {"message": "Account gelöscht."}
 
 

--- a/app/routers/backup.py
+++ b/app/routers/backup.py
@@ -11,7 +11,7 @@ from app.schemas import (
     BackupConfigCreate, BackupConfigResponse, BackupTriggerResponse,
     ScheduleUpdate, ScheduleResponse,
 )
-from app.services import backup_service, icloud_service
+from app.services import backup_service, icloud_service, storage_cache
 from app.services.notification import notify_backup_result, notify_token_expired
 from app.services.scheduler import check_token_expiry_for_account, sync_scheduled_jobs
 
@@ -119,6 +119,12 @@ async def trigger_backup(apple_id: str):
             apple_id, status=status, message=message, stats=stats,
             at=end_time.isoformat(), duration_seconds=duration,
         )
+        # Refresh cached iCloud storage breakdown so the dashboard shows
+        # up-to-date numbers without hitting Apple on every page load.
+        try:
+            await asyncio.to_thread(storage_cache.refresh, apple_id)
+        except Exception:
+            log.debug("Speicher-Cache-Refresh für %s fehlgeschlagen", apple_id, exc_info=True)
         notify_backup_result(apple_id, status, message)
 
     asyncio.create_task(_run())
@@ -208,6 +214,10 @@ async def trigger_all_backups():
                 apple_id, status=status, message=message, stats=stats,
                 at=end_time.isoformat(), duration_seconds=duration,
             )
+            try:
+                await asyncio.to_thread(storage_cache.refresh, apple_id)
+            except Exception:
+                log.debug("Speicher-Cache-Refresh für %s fehlgeschlagen", apple_id, exc_info=True)
             notify_backup_result(apple_id, status, message)
 
         asyncio.create_task(_run())

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -1,0 +1,74 @@
+"""API routes for global application settings (notifications, ...)."""
+
+import logging
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app import config_store
+
+log = logging.getLogger("icloud-backup")
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+class NotificationSettings(BaseModel):
+    dsm_notify: bool = False
+    pushover_enabled: bool = False
+    pushover_api_token: str = ""
+    pushover_user_key: str = ""
+    pushover_devices: str = ""
+
+
+def _redact(settings_dict: dict) -> dict:
+    """Never ship the full Pushover API token/user key to the browser."""
+    out = dict(settings_dict)
+    for key in ("pushover_api_token", "pushover_user_key"):
+        value = out.get(key) or ""
+        if value:
+            out[key] = "•" * 8 + value[-4:] if len(value) > 4 else "•" * len(value)
+    return out
+
+
+class NotificationSettingsResponse(BaseModel):
+    dsm_notify: bool
+    pushover_enabled: bool
+    pushover_api_token_set: bool
+    pushover_user_key_set: bool
+    pushover_api_token_hint: str = ""
+    pushover_user_key_hint: str = ""
+    pushover_devices: str = ""
+
+
+def _to_response(data: dict) -> NotificationSettingsResponse:
+    redacted = _redact(data)
+    return NotificationSettingsResponse(
+        dsm_notify=bool(data.get("dsm_notify")),
+        pushover_enabled=bool(data.get("pushover_enabled")),
+        pushover_api_token_set=bool(data.get("pushover_api_token")),
+        pushover_user_key_set=bool(data.get("pushover_user_key")),
+        pushover_api_token_hint=redacted.get("pushover_api_token", "") if data.get("pushover_api_token") else "",
+        pushover_user_key_hint=redacted.get("pushover_user_key", "") if data.get("pushover_user_key") else "",
+        pushover_devices=data.get("pushover_devices") or "",
+    )
+
+
+@router.get("/notifications", response_model=NotificationSettingsResponse)
+async def get_notification_settings():
+    return _to_response(config_store.get_notifications())
+
+
+@router.post("/notifications", response_model=NotificationSettingsResponse)
+async def update_notification_settings(data: NotificationSettings):
+    current = config_store.get_notifications()
+    merged = dict(current)
+    merged["dsm_notify"] = data.dsm_notify
+    merged["pushover_enabled"] = data.pushover_enabled
+    merged["pushover_devices"] = data.pushover_devices
+    # Only overwrite secrets when the client actually sends a new value.
+    # An empty string means "leave the stored secret untouched".
+    if data.pushover_api_token:
+        merged["pushover_api_token"] = data.pushover_api_token
+    if data.pushover_user_key:
+        merged["pushover_user_key"] = data.pushover_user_key
+    saved = config_store.save_notifications(merged)
+    return _to_response(saved)

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -1,4 +1,8 @@
-"""Notification service – supports DSM (synodsmnotify) and Pushover."""
+"""Notification service – supports DSM (synodsmnotify) and Pushover.
+
+Settings are stored in the YAML config (``config_store.get_notifications``)
+so they can be edited from the web UI instead of docker-compose.yml.
+"""
 
 import json
 import logging
@@ -8,7 +12,7 @@ import subprocess
 import urllib.request
 import urllib.error
 
-from app.config import settings
+from app import config_store
 
 log = logging.getLogger("icloud-backup")
 
@@ -30,7 +34,7 @@ def send_dsm_notification(title: str, message: str) -> None:
 
     Does nothing when DSM_NOTIFY is disabled or the binary is missing.
     """
-    if not settings.dsm_notify:
+    if not config_store.get_notifications().get("dsm_notify"):
         return
 
     if not _binary_available():
@@ -83,26 +87,30 @@ _PUSHOVER_API_URL = "https://api.pushover.net/1/messages.json"
 def send_pushover_notification(title: str, message: str) -> None:
     """Send a push notification via the Pushover API.
 
-    Does nothing when PUSHOVER_ENABLED is false or credentials are missing.
+    Does nothing when Pushover is disabled or credentials are missing.
     """
-    if not settings.pushover_enabled:
+    notif = config_store.get_notifications()
+    if not notif.get("pushover_enabled"):
         return
 
-    if not settings.pushover_api_token or not settings.pushover_user_key:
+    token = notif.get("pushover_api_token") or ""
+    user = notif.get("pushover_user_key") or ""
+    devices = notif.get("pushover_devices") or ""
+    if not token or not user:
         log.warning(
-            "PUSHOVER_ENABLED ist aktiviert, aber PUSHOVER_API_TOKEN oder "
-            "PUSHOVER_USER_KEY fehlt."
+            "Pushover ist aktiviert, aber API-Token oder User-Key fehlt. "
+            "Bitte in den Benachrichtigungseinstellungen ergänzen."
         )
         return
 
     data = {
-        "token": settings.pushover_api_token,
-        "user": settings.pushover_user_key,
+        "token": token,
+        "user": user,
         "title": title,
         "message": message,
     }
-    if settings.pushover_devices:
-        data["device"] = settings.pushover_devices
+    if devices:
+        data["device"] = devices
 
     payload = json.dumps(data).encode()
 

--- a/app/services/storage_cache.py
+++ b/app/services/storage_cache.py
@@ -1,0 +1,87 @@
+"""Persistent cache for iCloud storage usage data.
+
+The dashboard displays per-account storage breakdown (photos, drive, backups,
+mail, ...). Fetching this from Apple on every page load is slow and can hit
+rate limits, so we cache the result to disk and refresh it after each backup.
+"""
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.config import settings
+from app.services import icloud_service
+
+log = logging.getLogger("icloud-backup")
+
+_lock = threading.Lock()
+
+
+def _cache_path(apple_id: str) -> Path:
+    safe = (
+        apple_id.replace("@", "_at_")
+        .replace("/", "_")
+        .replace("\\", "_")
+        .replace("..", "_")
+    )
+    return settings.config_path / f".icloud-storage-cache-{safe}.json"
+
+
+def load_cache(apple_id: str) -> dict | None:
+    """Return cached storage data for *apple_id* or ``None`` when missing/invalid."""
+    path = _cache_path(apple_id)
+    if not path.exists():
+        return None
+    try:
+        with _lock:
+            raw = json.loads(path.read_text())
+    except Exception:
+        log.warning("Speicher-Cache für %s konnte nicht gelesen werden", apple_id, exc_info=True)
+        return None
+    data = raw.get("data")
+    if not isinstance(data, dict):
+        return None
+    data = dict(data)
+    data["fetched_at"] = raw.get("fetched_at")
+    return data
+
+
+def save_cache(apple_id: str, data: dict) -> None:
+    """Persist storage usage *data* for *apple_id*."""
+    path = _cache_path(apple_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "apple_id": apple_id,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "data": data,
+    }
+    tmp = path.with_suffix(".json.tmp")
+    with _lock:
+        tmp.write_text(json.dumps(payload, ensure_ascii=False))
+        tmp.replace(path)
+
+
+def delete_cache(apple_id: str) -> None:
+    """Remove the storage cache file for *apple_id* (used on account deletion)."""
+    path = _cache_path(apple_id)
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        log.debug("Speicher-Cache für %s konnte nicht gelöscht werden", apple_id, exc_info=True)
+
+
+def refresh(apple_id: str) -> dict | None:
+    """Fetch fresh storage usage from iCloud and update the cache.
+
+    Returns the fetched data (with ``fetched_at``) or ``None`` when the API
+    call failed. Existing cache is kept on failure.
+    """
+    data = icloud_service.get_storage_usage(apple_id)
+    if data is None:
+        log.info("iCloud-Speicherinfo für %s nicht abrufbar – Cache bleibt unverändert", apple_id)
+        return None
+    save_cache(apple_id, data)
+    log.info("iCloud-Speicherinfo für %s aktualisiert", apple_id)
+    return load_cache(apple_id)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,6 +23,9 @@
                 <a href="/logs" class="btn btn-outline-secondary btn-sm">
                     <i class="bi bi-journal-text me-1"></i> Logs
                 </a>
+                <a href="/settings" class="btn btn-outline-secondary btn-sm">
+                    <i class="bi bi-gear me-1"></i> Einstellungen
+                </a>
                 <form method="POST" action="/logout" class="d-inline">
                     <button type="submit" class="btn btn-outline-secondary btn-sm">
                         <i class="bi bi-box-arrow-right me-1"></i> Logout

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,178 @@
+{% extends "base.html" %}
+{% block title %}iCloud Backup – Einstellungen{% endblock %}
+
+{% block content %}
+<div x-data="notificationSettings()" x-init="init()">
+    <h1 class="h3 mb-4">Einstellungen</h1>
+
+    <div class="card mb-4">
+        <div class="card-header d-flex align-items-center gap-2">
+            <i class="bi bi-bell fs-5"></i>
+            <strong>Benachrichtigungen</strong>
+        </div>
+        <div class="card-body">
+            <p class="text-body-secondary small">
+                Benachrichtigungen werden bei fehlerhaften Backups und
+                ablaufenden iCloud-Tokens versendet. Die Konfiguration wird in
+                <code>/config/config.yaml</code> gespeichert.
+            </p>
+
+            <div x-show="loading" class="text-center py-3">
+                <span class="spinner-border spinner-border-sm"></span>
+                Lade Einstellungen…
+            </div>
+
+            <form x-show="!loading" @submit.prevent="save()" class="mt-2">
+                <!-- DSM -->
+                <h6 class="mt-2">Synology DSM</h6>
+                <div class="form-check form-switch mb-3">
+                    <input class="form-check-input" type="checkbox" id="dsmNotify"
+                           x-model="form.dsm_notify">
+                    <label class="form-check-label" for="dsmNotify">
+                        DSM-Benachrichtigungen aktivieren
+                    </label>
+                    <div class="form-text">
+                        Erfordert eingehängte Volumes
+                        <code>/usr/syno/bin/synodsmnotify</code> und
+                        <code>/usr/lib</code> (siehe README).
+                    </div>
+                </div>
+
+                <hr>
+
+                <!-- Pushover -->
+                <h6 class="mt-2">Pushover</h6>
+                <div class="form-check form-switch mb-3">
+                    <input class="form-check-input" type="checkbox" id="pushoverEnabled"
+                           x-model="form.pushover_enabled">
+                    <label class="form-check-label" for="pushoverEnabled">
+                        Pushover-Push-Benachrichtigungen aktivieren
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">API-Token</label>
+                    <input type="password" class="form-control font-monospace"
+                           x-model="form.pushover_api_token"
+                           :placeholder="current.pushover_api_token_set ? current.pushover_api_token_hint + ' (gespeichert – leer lassen um beizubehalten)' : 'a1b2c3d4...'">
+                    <div class="form-text">
+                        Application-Token aus deiner
+                        <a href="https://pushover.net/apps" target="_blank">Pushover-App</a>.
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">User-Key</label>
+                    <input type="password" class="form-control font-monospace"
+                           x-model="form.pushover_user_key"
+                           :placeholder="current.pushover_user_key_set ? current.pushover_user_key_hint + ' (gespeichert – leer lassen um beizubehalten)' : 'u1v2w3x4...'">
+                    <div class="form-text">
+                        Dein persönlicher User-Key (siehe
+                        <a href="https://pushover.net/" target="_blank">Pushover-Dashboard</a>).
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Geräte (optional)</label>
+                    <input type="text" class="form-control"
+                           x-model="form.pushover_devices"
+                           placeholder="iphone,ipad">
+                    <div class="form-text">
+                        Kommaseparierte Geräte-Namen. Leer = alle Geräte.
+                    </div>
+                </div>
+
+                <div class="d-flex align-items-center gap-3">
+                    <button type="submit" class="btn btn-primary" :disabled="saving">
+                        <span x-show="saving" class="spinner-border spinner-border-sm me-1"></span>
+                        <i class="bi bi-check-lg me-1" x-show="!saving"></i>
+                        Speichern
+                    </button>
+                    <span x-show="saved" x-transition class="text-success small">
+                        <i class="bi bi-check-lg"></i> Gespeichert
+                    </span>
+                    <span x-show="error" x-transition class="text-danger small" x-text="error"></span>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function notificationSettings() {
+    return {
+        loading: true,
+        saving: false,
+        saved: false,
+        error: '',
+        current: {
+            dsm_notify: false,
+            pushover_enabled: false,
+            pushover_api_token_set: false,
+            pushover_user_key_set: false,
+            pushover_api_token_hint: '',
+            pushover_user_key_hint: '',
+            pushover_devices: '',
+        },
+        form: {
+            dsm_notify: false,
+            pushover_enabled: false,
+            pushover_api_token: '',
+            pushover_user_key: '',
+            pushover_devices: '',
+        },
+
+        async init() {
+            await this.load();
+        },
+
+        async load() {
+            this.loading = true;
+            try {
+                const res = await fetch('/api/settings/notifications');
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                const data = await res.json();
+                this.current = data;
+                this.form.dsm_notify = data.dsm_notify;
+                this.form.pushover_enabled = data.pushover_enabled;
+                this.form.pushover_devices = data.pushover_devices || '';
+                // Secrets are never returned – keep inputs empty so submit keeps current values.
+                this.form.pushover_api_token = '';
+                this.form.pushover_user_key = '';
+            } catch (e) {
+                this.error = 'Einstellungen konnten nicht geladen werden: ' + e.message;
+            }
+            this.loading = false;
+        },
+
+        async save() {
+            this.saving = true;
+            this.saved = false;
+            this.error = '';
+            try {
+                const res = await fetch('/api/settings/notifications', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(this.form),
+                });
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({}));
+                    throw new Error(err.detail || ('HTTP ' + res.status));
+                }
+                const data = await res.json();
+                this.current = data;
+                this.form.pushover_api_token = '';
+                this.form.pushover_user_key = '';
+                this.saved = true;
+                setTimeout(() => this.saved = false, 3000);
+            } catch (e) {
+                this.error = 'Speichern fehlgeschlagen: ' + e.message;
+            }
+            this.saving = false;
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,7 @@ services:
     environment:
       - TZ=${TZ:-Europe/Berlin}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - DSM_NOTIFY=${DSM_NOTIFY:-false}
-      # Pushover push notifications (https://pushover.net)
-      - PUSHOVER_ENABLED=${PUSHOVER_ENABLED:-false}
-      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
-      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
-      - PUSHOVER_DEVICES=${PUSHOVER_DEVICES:-}
+      # Notifications (DSM / Pushover) werden in der Web-Oberfläche unter
+      # "Einstellungen" konfiguriert und in /config/config.yaml gespeichert.
       # - AUTH_PASSWORD=mein-sicheres-passwort  # If not set, a random password is logged on startup
       # - SECRET_KEY=...  # Optional; falls back to AUTH_PASSWORD if not set

--- a/tests/test_notifications_settings.py
+++ b/tests/test_notifications_settings.py
@@ -1,0 +1,107 @@
+"""Tests for GUI-managed notification settings."""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+
+from app.auth import _COOKIE_NAME, create_session_cookie
+from app.main import app
+from app import config_store
+from app.services import notification
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_store, "_CONFIG_FILE", tmp_path / "config.yaml")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={_COOKIE_NAME: create_session_cookie()},
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_defaults_when_nothing_saved(client):
+    res = await client.get("/api/settings/notifications")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["dsm_notify"] is False
+    assert data["pushover_enabled"] is False
+    assert data["pushover_api_token_set"] is False
+    assert data["pushover_user_key_set"] is False
+    assert data["pushover_devices"] == ""
+
+
+@pytest.mark.asyncio
+async def test_save_full_settings(client):
+    payload = {
+        "dsm_notify": True,
+        "pushover_enabled": True,
+        "pushover_api_token": "abcdefghij1234567890",
+        "pushover_user_key": "uvwxyz1234567890abcd",
+        "pushover_devices": "iphone,ipad",
+    }
+    res = await client.post("/api/settings/notifications", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["dsm_notify"] is True
+    assert data["pushover_enabled"] is True
+    assert data["pushover_api_token_set"] is True
+    assert data["pushover_user_key_set"] is True
+    assert data["pushover_devices"] == "iphone,ipad"
+    # API must never return the full secret
+    assert "abcdefghij" not in data["pushover_api_token_hint"]
+    assert data["pushover_api_token_hint"].endswith("7890")
+
+    stored = config_store.get_notifications()
+    assert stored["pushover_api_token"] == "abcdefghij1234567890"
+    assert stored["pushover_user_key"] == "uvwxyz1234567890abcd"
+
+
+@pytest.mark.asyncio
+async def test_empty_secret_keeps_stored_value(client):
+    config_store.save_notifications({
+        "dsm_notify": False,
+        "pushover_enabled": True,
+        "pushover_api_token": "keep-me-token",
+        "pushover_user_key": "keep-me-user",
+        "pushover_devices": "",
+    })
+    # Simulate the GUI: user toggles something but leaves the token input empty.
+    payload = {
+        "dsm_notify": True,
+        "pushover_enabled": True,
+        "pushover_api_token": "",
+        "pushover_user_key": "",
+        "pushover_devices": "iphone",
+    }
+    res = await client.post("/api/settings/notifications", json=payload)
+    assert res.status_code == 200
+
+    stored = config_store.get_notifications()
+    assert stored["dsm_notify"] is True
+    assert stored["pushover_api_token"] == "keep-me-token"
+    assert stored["pushover_user_key"] == "keep-me-user"
+    assert stored["pushover_devices"] == "iphone"
+
+
+def test_pushover_respects_config_store_toggle(monkeypatch, tmp_path):
+    monkeypatch.setattr(config_store, "_CONFIG_FILE", tmp_path / "config.yaml")
+    # Disabled: nothing should be sent.
+    config_store.save_notifications({
+        "dsm_notify": False,
+        "pushover_enabled": False,
+        "pushover_api_token": "token",
+        "pushover_user_key": "user",
+        "pushover_devices": "",
+    })
+
+    called = {"n": 0}
+    def _fake_urlopen(*args, **kwargs):
+        called["n"] += 1
+        raise AssertionError("urlopen must not be called when Pushover is disabled")
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    notification.send_pushover_notification("t", "m")
+    assert called["n"] == 0

--- a/tests/test_storage_cache.py
+++ b/tests/test_storage_cache.py
@@ -1,0 +1,64 @@
+"""Tests for the iCloud storage cache."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.config import settings
+from app.services import storage_cache
+
+
+@pytest.fixture
+def temp_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "config_path", tmp_path)
+    yield tmp_path
+
+
+def test_cache_roundtrip(temp_config):
+    apple_id = "alice@icloud.com"
+    assert storage_cache.load_cache(apple_id) is None
+
+    payload = {
+        "used_bytes": 1234,
+        "total_bytes": 5000,
+        "available_bytes": 3766,
+        "used_percent": 24.6,
+        "quota_over": False,
+        "media": [{"key": "photos", "label": "Fotos", "color": "#fff", "usage_bytes": 1234}],
+    }
+    storage_cache.save_cache(apple_id, payload)
+
+    loaded = storage_cache.load_cache(apple_id)
+    assert loaded["used_bytes"] == 1234
+    assert loaded["media"][0]["label"] == "Fotos"
+    assert "fetched_at" in loaded and loaded["fetched_at"]
+
+
+def test_delete_cache(temp_config):
+    apple_id = "bob@icloud.com"
+    storage_cache.save_cache(apple_id, {"used_bytes": 1})
+    assert storage_cache.load_cache(apple_id) is not None
+    storage_cache.delete_cache(apple_id)
+    assert storage_cache.load_cache(apple_id) is None
+
+
+def test_refresh_updates_cache(temp_config):
+    apple_id = "charlie@icloud.com"
+    fresh = {"used_bytes": 7, "total_bytes": 10, "media": []}
+    with patch("app.services.storage_cache.icloud_service.get_storage_usage", return_value=fresh):
+        result = storage_cache.refresh(apple_id)
+    assert result is not None
+    assert result["used_bytes"] == 7
+    # Second call with None must keep previous data.
+    with patch("app.services.storage_cache.icloud_service.get_storage_usage", return_value=None):
+        assert storage_cache.refresh(apple_id) is None
+    still = storage_cache.load_cache(apple_id)
+    assert still is not None
+    assert still["used_bytes"] == 7
+
+
+def test_cache_path_is_filesystem_safe(temp_config):
+    # '@' and '/' are sanitised to avoid path traversal or unexpected subdirs.
+    path = storage_cache._cache_path("alice@icloud.com/../evil")
+    assert ".." not in path.name
+    assert path.parent == temp_config


### PR DESCRIPTION
## Summary
This PR moves notification configuration (DSM and Pushover) from environment variables to the web UI, allowing users to manage settings without restarting the container. It also introduces persistent caching of iCloud storage usage data to improve dashboard performance and reduce API calls to Apple.

## Key Changes

### Notification Settings Management
- **New settings API** (`app/routers/settings.py`): GET/POST endpoints for managing global notification settings
- **Config store integration** (`app/config_store.py`): Added `get_notifications()` and `save_notifications()` functions to persist settings in `config.yaml`
- **Settings UI** (`app/templates/settings.html`): New settings page with toggles and input fields for DSM and Pushover configuration
- **Secret handling**: API never returns full API tokens/user keys to the browser; only redacted hints (last 4 chars) are shown. Empty inputs on save preserve existing secrets.
- **Notification service update** (`app/services/notification.py`): Refactored to read settings from config store instead of environment variables

### iCloud Storage Caching
- **New storage cache service** (`app/services/storage_cache.py`): Persistent disk cache for per-account storage usage data with thread-safe operations
- **Cache refresh on backup** (`app/routers/backup.py`): Storage cache is automatically refreshed after each successful backup
- **Smart cache loading** (`app/routers/accounts.py`): `/api/accounts/{id}/icloud-storage` endpoint now:
  - Returns cached data by default (fast, no API call)
  - Supports `?refresh=true` query parameter to force fresh fetch from Apple
  - Falls back to one-shot fetch if no cache exists yet
- **Cache cleanup**: Storage cache is deleted when an account is removed

### Configuration Changes
- **Removed environment variables**: `DSM_NOTIFY`, `PUSHOVER_ENABLED`, `PUSHOVER_API_TOKEN`, `PUSHOVER_USER_KEY`, `PUSHOVER_DEVICES` are no longer read from `docker-compose.yml`
- **Settings persistence**: All notification settings are now stored in `/config/config.yaml` under a `notifications` key
- **Backward compatibility**: Default values are applied for missing keys; existing environment variable configuration is not migrated automatically

### UI Updates
- Added "Einstellungen" (Settings) button to navigation bar
- Settings page includes help text and links to external documentation (Pushover)
- Responsive form with loading states, save feedback, and error messages

## Testing
- Comprehensive test suite for notification settings API (`tests/test_notifications_settings.py`)
- Storage cache tests including roundtrip persistence, deletion, and refresh behavior (`tests/test_storage_cache.py`)
- Tests verify secret handling (empty inputs preserve stored values) and toggle behavior

https://claude.ai/code/session_01LVdGg8ZzXL4wcwCR4rkDLy