### PR TITLE
fix: DSM notifications for DSM 7.x use DSMSupportFormCustomMessage + …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-04-19
+
+### Fixed
+- **DSM notifications now work on DSM 7.x** – `synodsmnotify` in DSM 7.3
+  requires the positional `title` argument to be a registered mail-string key
+  and the `msg` argument to be a JSON object mapping placeholders to values.
+  The service now invokes
+  `synodsmnotify @administrators DSMSupportFormCustomMessage '{"CUSTOM_MSG":"…"}'`,
+  which uses the built-in `DSMSupportFormCustomMessage` template (a single
+  `%CUSTOM_MSG%` placeholder, no hardcoded subject/title). Notifications appear
+  in DSM's notification center and are routed through the user's configured
+  Synology notification channels (mail, push, SMS, …). Previously this
+  segfaulted (`rc=-11`) or returned `title: '…' is neither mail string key nor
+  i18n format.`.
+
 ## [0.9.17] - 2026-04-19
 
 ### Changed

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -23,23 +23,42 @@ log = logging.getLogger("icloud-backup")
 _SYNODSMNOTIFY = "/usr/local/bin/synodsmnotify"
 _SYNO_LIB_DIR = "/usr/syno/lib"
 
+# DSM 7.x requires the positional "title" arg to be a registered mail string
+# key and the "msg" arg to be a JSON object whose keys map to the placeholders
+# defined in that mail template. We use the built-in ``DSMSupportFormCustomMessage``
+# template, which exposes a single free-form placeholder ``%CUSTOM_MSG%`` and
+# has no hardcoded title/subject, so our own text is rendered verbatim.
+_DSM_MAIL_KEY = "DSMSupportFormCustomMessage"
+
 
 def _binary_available() -> bool:
     """Check whether synodsmnotify is available in the container."""
     return shutil.which(_SYNODSMNOTIFY) is not None
 
 
+def _dsm_env() -> dict:
+    env = os.environ.copy()
+    env["LD_LIBRARY_PATH"] = _SYNO_LIB_DIR + ":" + env.get("LD_LIBRARY_PATH", "")
+    return env
+
+
+def _dsm_payload(title: str, message: str) -> str:
+    """Build the JSON string for the synodsmnotify ``msg`` positional arg."""
+    text = f"{title}: {message}" if title and message else (title or message)
+    return json.dumps({"CUSTOM_MSG": text})
+
+
 def send_dsm_notification(title: str, message: str) -> None:
     """Send a DSM notification via synodsmnotify.
 
-    Does nothing when DSM_NOTIFY is disabled or the binary is missing.
+    Does nothing when DSM notifications are disabled or the binary is missing.
     """
     if not config_store.get_notifications().get("dsm_notify"):
         return
 
     if not _binary_available():
         log.warning(
-            "DSM_NOTIFY ist aktiviert, aber %s wurde nicht gefunden. "
+            "DSM-Benachrichtigungen sind aktiviert, aber %s wurde nicht gefunden. "
             "Bitte die Volumes /usr/syno/bin/synodsmnotify:%s:ro und "
             "/usr/lib:%s:ro in docker-compose.yml einbinden.",
             _SYNODSMNOTIFY,
@@ -48,16 +67,13 @@ def send_dsm_notification(title: str, message: str) -> None:
         )
         return
 
-    env = os.environ.copy()
-    env["LD_LIBRARY_PATH"] = _SYNO_LIB_DIR + ":" + env.get("LD_LIBRARY_PATH", "")
-
     try:
         subprocess.run(
-            [_SYNODSMNOTIFY, "@administrators", title, message],
+            [_SYNODSMNOTIFY, "@administrators", _DSM_MAIL_KEY, _dsm_payload(title, message)],
             timeout=10,
             check=True,
             capture_output=True,
-            env=env,
+            env=_dsm_env(),
         )
         log.info("DSM-Benachrichtigung gesendet: %s", title)
     except subprocess.CalledProcessError as exc:
@@ -190,16 +206,13 @@ def test_dsm() -> dict:
             ),
         }
 
-    env = os.environ.copy()
-    env["LD_LIBRARY_PATH"] = _SYNO_LIB_DIR + ":" + env.get("LD_LIBRARY_PATH", "")
-
     try:
         subprocess.run(
-            [_SYNODSMNOTIFY, "@administrators", _TEST_TITLE, _TEST_MESSAGE],
+            [_SYNODSMNOTIFY, "@administrators", _DSM_MAIL_KEY, _dsm_payload(_TEST_TITLE, _TEST_MESSAGE)],
             timeout=10,
             check=True,
             capture_output=True,
-            env=env,
+            env=_dsm_env(),
         )
         log.info("DSM-Testbenachrichtigung gesendet")
         return {"success": True, "message": "DSM-Testbenachrichtigung gesendet."}

--- a/tests/test_notifications_settings.py
+++ b/tests/test_notifications_settings.py
@@ -126,6 +126,55 @@ async def test_test_endpoint_dsm_reports_missing_binary(client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_test_endpoint_dsm_invokes_synodsmnotify_with_json_payload(client, monkeypatch):
+    """DSM 7.x requires the mail-string-key + JSON-payload argument form."""
+    import json as _json
+    monkeypatch.setattr(notification, "_binary_available", lambda: True)
+
+    captured = {}
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env", {})
+        return _FakeCompleted()
+
+    monkeypatch.setattr(notification.subprocess, "run", _fake_run)
+
+    res = await client.post("/api/settings/notifications/test", json={"backend": "dsm"})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+
+    cmd = captured["cmd"]
+    assert cmd[0] == notification._SYNODSMNOTIFY
+    assert cmd[1] == "@administrators"
+    assert cmd[2] == "DSMSupportFormCustomMessage"
+    payload = _json.loads(cmd[3])
+    assert set(payload.keys()) == {"CUSTOM_MSG"}
+    assert "Testnachricht" in payload["CUSTOM_MSG"]
+    # LD_LIBRARY_PATH must be prefixed with the Synology lib directory.
+    assert captured["env"]["LD_LIBRARY_PATH"].startswith(notification._SYNO_LIB_DIR)
+
+
+def test_dsm_payload_builds_single_custom_msg_key():
+    payload = notification._dsm_payload("Titel", "Nachricht")
+    import json as _json
+    data = _json.loads(payload)
+    assert data == {"CUSTOM_MSG": "Titel: Nachricht"}
+
+
+def test_dsm_payload_handles_empty_title():
+    import json as _json
+    assert _json.loads(notification._dsm_payload("", "foo")) == {"CUSTOM_MSG": "foo"}
+    assert _json.loads(notification._dsm_payload("bar", "")) == {"CUSTOM_MSG": "bar"}
+
+
+@pytest.mark.asyncio
 async def test_test_endpoint_pushover_requires_credentials(client):
     config_store.save_notifications({
         "dsm_notify": False,


### PR DESCRIPTION
…JSON payload

DSM 7.3's synodsmnotify requires the positional title arg to be a registered mail-string key and the msg arg to be a JSON object mapping placeholders to values. Previously the binary segfaulted (rc=-11) or returned 'title: ... is neither mail string key nor i18n format.'

Switches to the built-in DSMSupportFormCustomMessage template (single %CUSTOM_MSG% placeholder, no hardcoded subject) and passes title+message as JSON:

    synodsmnotify @administrators DSMSupportFormCustomMessage '{"CUSTOM_MSG":"..."}'

Adds a unit test verifying the exact argv form and LD_LIBRARY_PATH env.

Release as v0.9.18.