### PR TITLE
Remove Synology DSM notifications (v0.9.20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,15 +13,8 @@ TZ=Europe/Berlin
 # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
 
-# Synology DSM notifications (true/false)
-DSM_NOTIFY=false
-
-# Pushover push notifications (https://pushover.net)
-PUSHOVER_ENABLED=false
-PUSHOVER_API_TOKEN=
-PUSHOVER_USER_KEY=
-# Optional: comma-separated device names (empty = all devices)
-PUSHOVER_DEVICES=
+# Notifications (Pushover) are configured in the web UI under "Einstellungen"
+# and stored in /config/config.yaml.
 
 # Secret key for session encryption (change this!)
 SECRET_KEY=change-me-in-production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ app/
 │   ├── icloud_service.py    # pyicloud wrapper (auth, 2FA, 2SA, Drive, Contacts, Calendar)
 │   ├── backup_service.py    # Core backup logic (Drive, Photos, Contacts, Calendar)
 │   ├── scheduler.py         # APScheduler cron job management
-│   ├── notification.py      # Synology DSM notifications (synodsmnotify)
+│   ├── notification.py      # Pushover push notifications
 │   └── log_handler.py       # Ring buffer for live log viewer
 ├── static/              # CSS, JS
 └── templates/           # Jinja2 (login, dashboard, config, logs)
@@ -144,8 +144,10 @@ uvicorn app.main:app --reload --host 0.0.0.0 --port 8080
 | `CONFIG_PATH` | `./config` | Host path for configuration & sessions |
 | `ARCHIVE_PATH` | `./archive` | Host path for archived files (sync policy = "archive") |
 | `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `DSM_NOTIFY` | `false` | Enable Synology DSM notifications (`synodsmnotify`) |
 | `TZ` | `Europe/Berlin` | Container timezone |
+
+> Pushover notification settings are stored in `/config/config.yaml` and
+> configured via the web UI (Einstellungen), not via environment variables.
 
 ## Changelog & Release Process
 
@@ -162,4 +164,4 @@ uvicorn app.main:app --reload --host 0.0.0.0 --port 8080
 - **Exclusion paths:** Must work for both top-level and subfolder paths (e.g. `Documents/subfolder`).
 - **Log level changes:** `LOG_LEVEL` env var is applied at startup via `config.py`. The log handler uses a ring buffer (`log_handler.py`) that captures all levels.
 - **Special characters in folder names:** `#`, `%`, `?`, `&`, `+` in iCloud Drive folder or file names can cause 404 errors during download. `_open_drive_node()` provides fallback strategies, but renaming the folder is the safest fix.
-- **Env var naming:** The Synology notification variable is `DSM_NOTIFY`, not `SYNOLOGY_NOTIFY`.
+- **Notifications:** Only Pushover is supported. Configuration lives in `/config/config.yaml` (managed via the web UI under *Einstellungen*), not in environment variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.20] - 2026-04-19
+
+### Removed
+- **Synology DSM notifications** – Removed completely. Even when invoked with
+  the correct DSM 7.3 syntax, `synodsmnotify` consistently segfaulted inside
+  the container because the bundled Synology C++ libraries require a DSM
+  runtime environment that cannot be reproduced in a generic Docker image.
+  Pushover remains the only supported notification backend. The `DSM_NOTIFY`
+  environment variable, the `dsm_notify` config key, the DSM section in the
+  *Einstellungen* UI, and the `synodsmnotify` / `/usr/lib` volume mounts in
+  the Synology docker-compose example have all been removed. Any stored
+  `dsm_notify` values in `/config/config.yaml` are ignored.
+
 ## [0.9.18] - 2026-04-19
 
 ### Fixed
-- **DSM notifications now work on DSM 7.x** – `synodsmnotify` in DSM 7.3
-  requires the positional `title` argument to be a registered mail-string key
-  and the `msg` argument to be a JSON object mapping placeholders to values.
-  The service now invokes
-  `synodsmnotify @administrators DSMSupportFormCustomMessage '{"CUSTOM_MSG":"…"}'`,
-  which uses the built-in `DSMSupportFormCustomMessage` template (a single
-  `%CUSTOM_MSG%` placeholder, no hardcoded subject/title). Notifications appear
-  in DSM's notification center and are routed through the user's configured
-  Synology notification channels (mail, push, SMS, …). Previously this
-  segfaulted (`rc=-11`) or returned `title: '…' is neither mail string key nor
-  i18n format.`.
+- **DSM notifications call format updated for DSM 7.x** – `synodsmnotify` in
+  DSM 7.3 requires the positional `title` argument to be a registered
+  mail-string key and the `msg` argument to be a JSON object mapping
+  placeholders to values. The service was updated to use
+  `DSMSupportFormCustomMessage` with a `{"CUSTOM_MSG":"…"}` payload, fixing
+  the previous `title: '…' is neither mail string key nor i18n format.`
+  error. (Superseded by the full removal of DSM support in 0.9.19 after the
+  binary still segfaulted inside the container despite the correct syntax.)
 
 ## [0.9.17] - 2026-04-19
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -14,7 +14,6 @@ Back up your **iCloud Drive** and **iCloud Photos** automatically with a simple 
 - Etag caching for fast incremental backups
 - Live progress, backup duration & built-in log viewer
 - Pushover push notifications for backup errors and expiring tokens
-- Synology DSM notifications via `synodsmnotify`
 - Multi-arch: `linux/amd64` and `linux/arm64`
 
 ## Quick Start
@@ -54,13 +53,11 @@ Open **http://localhost:8080** and log in.
 | `AUTH_PASSWORD` | *(random)* | Web UI password. Random if not set (check logs). |
 | `SECRET_KEY` | *(uses AUTH_PASSWORD)* | Secret for cookie signing. Falls back to `AUTH_PASSWORD` if not set. |
 | `LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
-| `DSM_NOTIFY` | `false` | Enable Synology DSM notifications (`true`/`false`). |
-| `PUSHOVER_ENABLED` | `false` | Enable [Pushover](https://pushover.net) push notifications (`true`/`false`). |
-| `PUSHOVER_API_TOKEN` | – | Pushover application API token. |
-| `PUSHOVER_USER_KEY` | – | Pushover user key. |
-| `PUSHOVER_DEVICES` | *(all)* | Comma-separated device names to notify (empty = all devices). |
 | `ARCHIVE_PATH` | `./archive` | Host path for archived files (sync policy "archive"). |
 | `TZ` | `Europe/Berlin` | Container timezone. |
+
+> Pushover notifications are configured in the web UI under **Einstellungen**
+> and stored in `/config/config.yaml`.
 
 ## Volumes
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A Docker-based backup service for **iCloud Drive**, **iCloud Photos**, **iCloud 
 - **Scheduled Backups** – Configurable via cron expressions
 - **2FA Support** – Two-factor authentication directly through the web UI (device push & SMS)
 - **Pushover Notifications** – Push notifications for backup errors and expiring tokens via [Pushover](https://pushover.net), configurable in the web UI
-- **Synology Notifications** – Optional notifications via `synodsmnotify` on Synology NAS, configurable in the web UI
 - **Cached iCloud Storage** – Storage breakdown is refreshed automatically after every backup and cached on disk
 - **Password Protection** – Web UI secured with password authentication
 - **Dark Mode UI** – Modern, responsive web interface
@@ -78,7 +77,7 @@ Zusätzlich wird die Version in der Web-UI im Footer angezeigt.
 | `LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `TZ` | `Europe/Berlin` | Timezone |
 
-> Notification settings (DSM and Pushover) are configured in the web UI under
+> Notification settings (Pushover) are configured in the web UI under
 > **Einstellungen** and stored in `/config/config.yaml`. They are no longer
 > set via environment variables.
 
@@ -111,7 +110,7 @@ services:
     environment:
       - TZ=${TZ:-Europe/Berlin}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      # Notifications (DSM / Pushover) are configured in the web UI
+      # Notifications (Pushover) are configured in the web UI
       # under "Einstellungen" and stored in /config/config.yaml.
       # - AUTH_PASSWORD=my-secure-password
       # - SECRET_KEY=...  # Optional; falls back to AUTH_PASSWORD if not set
@@ -178,16 +177,10 @@ services:
          - /volume1/docker/icloud-backup/backups:/backups
          - /volume1/docker/icloud-backup/config:/config
          - /volume1/docker/icloud-backup/archive:/archive
-         - /usr/syno/bin/synodsmnotify:/usr/local/bin/synodsmnotify:ro
-         - /usr/lib:/usr/syno/lib:ro
        environment:
          - TZ=Europe/Berlin
          - AUTH_PASSWORD=my-secure-password
    ```
-
-   > To enable DSM notifications, open the web UI → **Einstellungen** and
-   > toggle "DSM-Benachrichtigungen aktivieren". The mounts above
-   > (`synodsmnotify` + `/usr/lib`) are still required.
 
 5. **Start the project** → Container Manager builds and starts the container
 

--- a/app/config_store.py
+++ b/app/config_store.py
@@ -105,7 +105,6 @@ def _default_schedule() -> dict:
 
 def _default_notifications() -> dict:
     return {
-        "dsm_notify": False,
         "pushover_enabled": False,
         "pushover_api_token": "",
         "pushover_user_key": "",
@@ -341,7 +340,6 @@ def save_notifications(settings_dict: dict) -> dict:
     defaults = _default_notifications()
     clean = {k: settings_dict.get(k, defaults[k]) for k in defaults}
     # Coerce booleans so YAML doesn't end up with "true"/"false" strings.
-    clean["dsm_notify"] = bool(clean["dsm_notify"])
     clean["pushover_enabled"] = bool(clean["pushover_enabled"])
     for key in ("pushover_api_token", "pushover_user_key", "pushover_devices"):
         clean[key] = str(clean.get(key) or "")

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -15,7 +15,6 @@ router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 
 class NotificationSettings(BaseModel):
-    dsm_notify: bool = False
     pushover_enabled: bool = False
     pushover_api_token: str = ""
     pushover_user_key: str = ""
@@ -33,7 +32,6 @@ def _redact(settings_dict: dict) -> dict:
 
 
 class NotificationSettingsResponse(BaseModel):
-    dsm_notify: bool
     pushover_enabled: bool
     pushover_api_token_set: bool
     pushover_user_key_set: bool
@@ -45,7 +43,6 @@ class NotificationSettingsResponse(BaseModel):
 def _to_response(data: dict) -> NotificationSettingsResponse:
     redacted = _redact(data)
     return NotificationSettingsResponse(
-        dsm_notify=bool(data.get("dsm_notify")),
         pushover_enabled=bool(data.get("pushover_enabled")),
         pushover_api_token_set=bool(data.get("pushover_api_token")),
         pushover_user_key_set=bool(data.get("pushover_user_key")),
@@ -64,7 +61,6 @@ async def get_notification_settings():
 async def update_notification_settings(data: NotificationSettings):
     current = config_store.get_notifications()
     merged = dict(current)
-    merged["dsm_notify"] = data.dsm_notify
     merged["pushover_enabled"] = data.pushover_enabled
     merged["pushover_devices"] = data.pushover_devices
     # Only overwrite secrets when the client actually sends a new value.
@@ -78,7 +74,7 @@ async def update_notification_settings(data: NotificationSettings):
 
 
 class NotificationTestRequest(BaseModel):
-    backend: Literal["dsm", "pushover"]
+    backend: Literal["pushover"]
 
 
 class NotificationTestResponse(BaseModel):
@@ -89,9 +85,7 @@ class NotificationTestResponse(BaseModel):
 @router.post("/notifications/test", response_model=NotificationTestResponse)
 async def test_notification(data: NotificationTestRequest):
     """Send a one-off test notification via the selected backend."""
-    if data.backend == "dsm":
-        result = await asyncio.to_thread(notification.test_dsm)
-    elif data.backend == "pushover":
+    if data.backend == "pushover":
         result = await asyncio.to_thread(notification.test_pushover)
     else:  # pragma: no cover – pydantic already enforces this
         raise HTTPException(status_code=400, detail="Unbekannter Backend-Typ.")

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -1,4 +1,4 @@
-"""Notification service – supports DSM (synodsmnotify) and Pushover.
+"""Notification service – Pushover backend.
 
 Settings are stored in the YAML config (``config_store.get_notifications``)
 so they can be edited from the web UI instead of docker-compose.yml.
@@ -6,98 +6,17 @@ so they can be edited from the web UI instead of docker-compose.yml.
 
 import json
 import logging
-import os
-import shutil
-import subprocess
-import urllib.request
 import urllib.error
+import urllib.request
 
 from app import config_store
 
 log = logging.getLogger("icloud-backup")
 
-# ---------------------------------------------------------------------------
-# DSM (Synology) backend
-# ---------------------------------------------------------------------------
-
-_SYNODSMNOTIFY = "/usr/local/bin/synodsmnotify"
-_SYNO_LIB_DIR = "/usr/syno/lib"
-
-# DSM 7.x requires the positional "title" arg to be a registered mail string
-# key and the "msg" arg to be a JSON object whose keys map to the placeholders
-# defined in that mail template. We use the built-in ``DSMSupportFormCustomMessage``
-# template, which exposes a single free-form placeholder ``%CUSTOM_MSG%`` and
-# has no hardcoded title/subject, so our own text is rendered verbatim.
-_DSM_MAIL_KEY = "DSMSupportFormCustomMessage"
-
-
-def _binary_available() -> bool:
-    """Check whether synodsmnotify is available in the container."""
-    return shutil.which(_SYNODSMNOTIFY) is not None
-
-
-def _dsm_env() -> dict:
-    env = os.environ.copy()
-    env["LD_LIBRARY_PATH"] = _SYNO_LIB_DIR + ":" + env.get("LD_LIBRARY_PATH", "")
-    return env
-
-
-def _dsm_payload(title: str, message: str) -> str:
-    """Build the JSON string for the synodsmnotify ``msg`` positional arg."""
-    text = f"{title}: {message}" if title and message else (title or message)
-    return json.dumps({"CUSTOM_MSG": text})
-
-
-def send_dsm_notification(title: str, message: str) -> None:
-    """Send a DSM notification via synodsmnotify.
-
-    Does nothing when DSM notifications are disabled or the binary is missing.
-    """
-    if not config_store.get_notifications().get("dsm_notify"):
-        return
-
-    if not _binary_available():
-        log.warning(
-            "DSM-Benachrichtigungen sind aktiviert, aber %s wurde nicht gefunden. "
-            "Bitte die Volumes /usr/syno/bin/synodsmnotify:%s:ro und "
-            "/usr/lib:%s:ro in docker-compose.yml einbinden.",
-            _SYNODSMNOTIFY,
-            _SYNODSMNOTIFY,
-            _SYNO_LIB_DIR,
-        )
-        return
-
-    try:
-        subprocess.run(
-            [_SYNODSMNOTIFY, "@administrators", _DSM_MAIL_KEY, _dsm_payload(title, message)],
-            timeout=10,
-            check=True,
-            capture_output=True,
-            env=_dsm_env(),
-        )
-        log.info("DSM-Benachrichtigung gesendet: %s", title)
-    except subprocess.CalledProcessError as exc:
-        stderr = exc.stderr.decode(errors="replace")
-        if exc.returncode == 127 and "shared librar" in stderr:
-            log.warning(
-                "synodsmnotify fehlgeschlagen (rc=127): Shared Libraries fehlen. "
-                "Bitte /usr/lib:%s:ro als Volume einbinden. Detail: %s",
-                _SYNO_LIB_DIR,
-                stderr,
-            )
-        else:
-            log.warning("synodsmnotify fehlgeschlagen (rc=%d): %s", exc.returncode, stderr)
-    except FileNotFoundError:
-        log.warning("synodsmnotify nicht gefunden")
-    except Exception as exc:
-        log.warning("DSM-Benachrichtigung fehlgeschlagen: %s", exc)
-
-
-# ---------------------------------------------------------------------------
-# Pushover backend
-# ---------------------------------------------------------------------------
-
 _PUSHOVER_API_URL = "https://api.pushover.net/1/messages.json"
+
+_TEST_TITLE = "iCloud Backup – Testbenachrichtigung"
+_TEST_MESSAGE = "Dies ist eine Testnachricht aus dem iCloud-Backup-Service."
 
 
 def send_pushover_notification(title: str, message: str) -> None:
@@ -128,11 +47,9 @@ def send_pushover_notification(title: str, message: str) -> None:
     if devices:
         data["device"] = devices
 
-    payload = json.dumps(data).encode()
-
     req = urllib.request.Request(
         _PUSHOVER_API_URL,
-        data=payload,
+        data=json.dumps(data).encode(),
         headers={"Content-Type": "application/json"},
         method="POST",
     )
@@ -141,18 +58,16 @@ def send_pushover_notification(title: str, message: str) -> None:
         with urllib.request.urlopen(req, timeout=10):
             log.info("Pushover-Benachrichtigung gesendet: %s", title)
     except urllib.error.HTTPError as exc:
-        log.warning("Pushover-Benachrichtigung fehlgeschlagen (HTTP %d): %s", exc.code, exc.read().decode(errors="replace"))
+        log.warning(
+            "Pushover-Benachrichtigung fehlgeschlagen (HTTP %d): %s",
+            exc.code,
+            exc.read().decode(errors="replace"),
+        )
     except Exception as exc:
         log.warning("Pushover-Benachrichtigung fehlgeschlagen: %s", exc)
 
 
-# ---------------------------------------------------------------------------
-# Unified helpers – dispatch to all enabled backends
-# ---------------------------------------------------------------------------
-
 def _send(title: str, message: str) -> None:
-    """Send a notification to all enabled backends."""
-    send_dsm_notification(title, message)
     send_pushover_notification(title, message)
 
 
@@ -183,49 +98,6 @@ def notify_token_expired(apple_id: str) -> None:
         f"{apple_id}: Token ist abgelaufen. "
         "Zwei-Faktor-Authentifizierung erforderlich.",
     )
-
-
-# ---------------------------------------------------------------------------
-# Test helpers – bypass the "enabled" toggle and return structured results
-# so the UI can display a success/failure message.
-# ---------------------------------------------------------------------------
-
-_TEST_TITLE = "iCloud Backup – Testbenachrichtigung"
-_TEST_MESSAGE = "Dies ist eine Testnachricht aus dem iCloud-Backup-Service."
-
-
-def test_dsm() -> dict:
-    """Send a one-off DSM notification and report the result."""
-    if not _binary_available():
-        return {
-            "success": False,
-            "message": (
-                f"{_SYNODSMNOTIFY} wurde nicht gefunden. Bitte die Volumes "
-                f"/usr/syno/bin/synodsmnotify:{_SYNODSMNOTIFY}:ro und "
-                f"/usr/lib:{_SYNO_LIB_DIR}:ro in docker-compose.yml einbinden."
-            ),
-        }
-
-    try:
-        subprocess.run(
-            [_SYNODSMNOTIFY, "@administrators", _DSM_MAIL_KEY, _dsm_payload(_TEST_TITLE, _TEST_MESSAGE)],
-            timeout=10,
-            check=True,
-            capture_output=True,
-            env=_dsm_env(),
-        )
-        log.info("DSM-Testbenachrichtigung gesendet")
-        return {"success": True, "message": "DSM-Testbenachrichtigung gesendet."}
-    except subprocess.CalledProcessError as exc:
-        stderr = exc.stderr.decode(errors="replace").strip()
-        return {
-            "success": False,
-            "message": f"synodsmnotify fehlgeschlagen (rc={exc.returncode}): {stderr or '(keine Ausgabe)'}",
-        }
-    except FileNotFoundError:
-        return {"success": False, "message": "synodsmnotify nicht gefunden."}
-    except Exception as exc:
-        return {"success": False, "message": f"DSM-Benachrichtigung fehlgeschlagen: {exc}"}
 
 
 def test_pushover() -> dict:

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -11,7 +11,7 @@ from app import config_store
 from app.services import backup_service
 from app.services.notification import notify_backup_result, notify_token_expired, notify_token_expiring
 
-# Token age (in days) at which a DSM warning is sent.
+# Token age (in days) at which a warning notification is sent.
 _TOKEN_WARNING_DAYS = 50
 
 log = logging.getLogger("icloud-backup")
@@ -101,7 +101,7 @@ async def _run_backup_job(apple_id: str) -> None:
 
 
 def check_token_expiry_for_account(apple_id: str) -> None:
-    """Check token age for a single account and send a DSM warning if expiring."""
+    """Check token age for a single account and send a warning notification if expiring."""
     acc = config_store.get_account(apple_id)
     if acc is None:
         return
@@ -124,7 +124,7 @@ def check_token_expiry_for_account(apple_id: str) -> None:
 
 
 def _check_token_expiry() -> None:
-    """Check token age for all accounts and send DSM warnings for expiring tokens."""
+    """Check token age for all accounts and send warning notifications for expiring tokens."""
     for acc in config_store.list_accounts():
         check_token_expiry_for_account(acc["apple_id"])
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -23,37 +23,6 @@
             </div>
 
             <form x-show="!loading" @submit.prevent="save()" class="mt-2">
-                <!-- DSM -->
-                <h6 class="mt-2">Synology DSM</h6>
-                <div class="form-check form-switch mb-3">
-                    <input class="form-check-input" type="checkbox" id="dsmNotify"
-                           x-model="form.dsm_notify">
-                    <label class="form-check-label" for="dsmNotify">
-                        DSM-Benachrichtigungen aktivieren
-                    </label>
-                    <div class="form-text">
-                        Erfordert eingehängte Volumes
-                        <code>/usr/syno/bin/synodsmnotify</code> und
-                        <code>/usr/lib</code> (siehe README).
-                    </div>
-                </div>
-
-                <div class="d-flex align-items-center gap-2 mb-3">
-                    <button type="button" class="btn btn-outline-secondary btn-sm"
-                            @click="sendTest('dsm')" :disabled="testing.dsm">
-                        <span x-show="testing.dsm" class="spinner-border spinner-border-sm me-1"></span>
-                        <i class="bi bi-send me-1" x-show="!testing.dsm"></i>
-                        Testbenachrichtigung senden
-                    </button>
-                    <span x-show="testResult.dsm" x-transition
-                          class="small"
-                          :class="testResult.dsm && testResult.dsm.success ? 'text-success' : 'text-danger'"
-                          x-text="testResult.dsm ? testResult.dsm.message : ''">
-                    </span>
-                </div>
-
-                <hr>
-
                 <!-- Pushover -->
                 <h6 class="mt-2">Pushover</h6>
                 <div class="form-check form-switch mb-3">
@@ -139,10 +108,9 @@ function notificationSettings() {
         saving: false,
         saved: false,
         error: '',
-        testing: { dsm: false, pushover: false },
-        testResult: { dsm: null, pushover: null },
+        testing: { pushover: false },
+        testResult: { pushover: null },
         current: {
-            dsm_notify: false,
             pushover_enabled: false,
             pushover_api_token_set: false,
             pushover_user_key_set: false,
@@ -151,7 +119,6 @@ function notificationSettings() {
             pushover_devices: '',
         },
         form: {
-            dsm_notify: false,
             pushover_enabled: false,
             pushover_api_token: '',
             pushover_user_key: '',
@@ -169,7 +136,6 @@ function notificationSettings() {
                 if (!res.ok) throw new Error('HTTP ' + res.status);
                 const data = await res.json();
                 this.current = data;
-                this.form.dsm_notify = data.dsm_notify;
                 this.form.pushover_enabled = data.pushover_enabled;
                 this.form.pushover_devices = data.pushover_devices || '';
                 // Secrets are never returned – keep inputs empty so submit keeps current values.
@@ -215,7 +181,7 @@ function notificationSettings() {
             this.saving = true;
             this.saved = false;
             this.error = '';
-            this.testResult = { dsm: null, pushover: null };
+            this.testResult = { pushover: null };
             try {
                 const res = await fetch('/api/settings/notifications', {
                     method: 'POST',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,10 @@ services:
       - ${BACKUP_PATH:-./backups}:/backups
       - ${CONFIG_PATH:-./config}:/config
       - ${ARCHIVE_PATH:-./archive}:/archive
-      # Synology DSM notifications (uncomment on Synology NAS)
-      # - /usr/syno/bin/synodsmnotify:/usr/local/bin/synodsmnotify:ro
-      # - /usr/lib:/usr/syno/lib:ro
     environment:
       - TZ=${TZ:-Europe/Berlin}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      # Notifications (DSM / Pushover) werden in der Web-Oberfläche unter
+      # Benachrichtigungen (Pushover) werden in der Web-Oberfläche unter
       # "Einstellungen" konfiguriert und in /config/config.yaml gespeichert.
       # - AUTH_PASSWORD=mein-sicheres-passwort  # If not set, a random password is logged on startup
       # - SECRET_KEY=...  # Optional; falls back to AUTH_PASSWORD if not set

--- a/tests/test_notifications_settings.py
+++ b/tests/test_notifications_settings.py
@@ -27,17 +27,16 @@ async def test_defaults_when_nothing_saved(client):
     res = await client.get("/api/settings/notifications")
     assert res.status_code == 200
     data = res.json()
-    assert data["dsm_notify"] is False
     assert data["pushover_enabled"] is False
     assert data["pushover_api_token_set"] is False
     assert data["pushover_user_key_set"] is False
     assert data["pushover_devices"] == ""
+    assert "dsm_notify" not in data
 
 
 @pytest.mark.asyncio
 async def test_save_full_settings(client):
     payload = {
-        "dsm_notify": True,
         "pushover_enabled": True,
         "pushover_api_token": "abcdefghij1234567890",
         "pushover_user_key": "uvwxyz1234567890abcd",
@@ -46,7 +45,6 @@ async def test_save_full_settings(client):
     res = await client.post("/api/settings/notifications", json=payload)
     assert res.status_code == 200
     data = res.json()
-    assert data["dsm_notify"] is True
     assert data["pushover_enabled"] is True
     assert data["pushover_api_token_set"] is True
     assert data["pushover_user_key_set"] is True
@@ -63,7 +61,6 @@ async def test_save_full_settings(client):
 @pytest.mark.asyncio
 async def test_empty_secret_keeps_stored_value(client):
     config_store.save_notifications({
-        "dsm_notify": False,
         "pushover_enabled": True,
         "pushover_api_token": "keep-me-token",
         "pushover_user_key": "keep-me-user",
@@ -71,7 +68,6 @@ async def test_empty_secret_keeps_stored_value(client):
     })
     # Simulate the GUI: user toggles something but leaves the token input empty.
     payload = {
-        "dsm_notify": True,
         "pushover_enabled": True,
         "pushover_api_token": "",
         "pushover_user_key": "",
@@ -81,7 +77,6 @@ async def test_empty_secret_keeps_stored_value(client):
     assert res.status_code == 200
 
     stored = config_store.get_notifications()
-    assert stored["dsm_notify"] is True
     assert stored["pushover_api_token"] == "keep-me-token"
     assert stored["pushover_user_key"] == "keep-me-user"
     assert stored["pushover_devices"] == "iphone"
@@ -91,7 +86,6 @@ def test_pushover_respects_config_store_toggle(monkeypatch, tmp_path):
     monkeypatch.setattr(config_store, "_CONFIG_FILE", tmp_path / "config.yaml")
     # Disabled: nothing should be sent.
     config_store.save_notifications({
-        "dsm_notify": False,
         "pushover_enabled": False,
         "pushover_api_token": "token",
         "pushover_user_key": "user",
@@ -115,69 +109,15 @@ async def test_test_endpoint_rejects_unknown_backend(client):
 
 
 @pytest.mark.asyncio
-async def test_test_endpoint_dsm_reports_missing_binary(client, monkeypatch):
-    # Ensure the binary check returns False regardless of the host.
-    monkeypatch.setattr(notification, "_binary_available", lambda: False)
+async def test_test_endpoint_rejects_dsm_backend(client):
+    """DSM was removed; the endpoint must not accept it anymore."""
     res = await client.post("/api/settings/notifications/test", json={"backend": "dsm"})
-    assert res.status_code == 200
-    body = res.json()
-    assert body["success"] is False
-    assert "synodsmnotify" in body["message"]
-
-
-@pytest.mark.asyncio
-async def test_test_endpoint_dsm_invokes_synodsmnotify_with_json_payload(client, monkeypatch):
-    """DSM 7.x requires the mail-string-key + JSON-payload argument form."""
-    import json as _json
-    monkeypatch.setattr(notification, "_binary_available", lambda: True)
-
-    captured = {}
-
-    class _FakeCompleted:
-        returncode = 0
-        stdout = b""
-        stderr = b""
-
-    def _fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        captured["env"] = kwargs.get("env", {})
-        return _FakeCompleted()
-
-    monkeypatch.setattr(notification.subprocess, "run", _fake_run)
-
-    res = await client.post("/api/settings/notifications/test", json={"backend": "dsm"})
-    assert res.status_code == 200
-    body = res.json()
-    assert body["success"] is True
-
-    cmd = captured["cmd"]
-    assert cmd[0] == notification._SYNODSMNOTIFY
-    assert cmd[1] == "@administrators"
-    assert cmd[2] == "DSMSupportFormCustomMessage"
-    payload = _json.loads(cmd[3])
-    assert set(payload.keys()) == {"CUSTOM_MSG"}
-    assert "Testnachricht" in payload["CUSTOM_MSG"]
-    # LD_LIBRARY_PATH must be prefixed with the Synology lib directory.
-    assert captured["env"]["LD_LIBRARY_PATH"].startswith(notification._SYNO_LIB_DIR)
-
-
-def test_dsm_payload_builds_single_custom_msg_key():
-    payload = notification._dsm_payload("Titel", "Nachricht")
-    import json as _json
-    data = _json.loads(payload)
-    assert data == {"CUSTOM_MSG": "Titel: Nachricht"}
-
-
-def test_dsm_payload_handles_empty_title():
-    import json as _json
-    assert _json.loads(notification._dsm_payload("", "foo")) == {"CUSTOM_MSG": "foo"}
-    assert _json.loads(notification._dsm_payload("bar", "")) == {"CUSTOM_MSG": "bar"}
+    assert res.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_test_endpoint_pushover_requires_credentials(client):
     config_store.save_notifications({
-        "dsm_notify": False,
         "pushover_enabled": True,
         "pushover_api_token": "",
         "pushover_user_key": "",
@@ -193,7 +133,6 @@ async def test_test_endpoint_pushover_requires_credentials(client):
 @pytest.mark.asyncio
 async def test_test_endpoint_pushover_success(client, monkeypatch):
     config_store.save_notifications({
-        "dsm_notify": False,
         "pushover_enabled": True,
         "pushover_api_token": "token-abc",
         "pushover_user_key": "user-xyz",


### PR DESCRIPTION
Even with the correct DSM 7.3 call format, synodsmnotify consistently segfaulted inside the container because the Synology C++ runtime cannot be reproduced in a generic Docker image. Pushover remains the only supported notification backend.

- Drop DSM_NOTIFY / dsm_notify config key and the DSM section in the Einstellungen UI.
- Remove synodsmnotify + /usr/lib volume mounts from the Synology docker-compose example.
- Reject the "dsm" backend in POST /api/settings/notifications/test (now Literal["pushover"] only).
- Update notification tests to cover the Pushover-only surface.
- Document the removal in CHANGELOG.md as v0.9.20.