### PR TITLE
Fix zombie processes by adding tini init system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Zombie `[curl] <defunct>` Prozesse** – Der Container lief mit `uvicorn`
+  als PID 1 ohne Init. Die Docker `HEALTHCHECK`-Aufrufe von `curl` (alle 30 s
+  via `sh -c`) wurden nach Beenden ihrer Shell-Wrapper an PID 1 reparented,
+  aber von uvicorn nicht reaped, sodass sich Hunderte Zombies ansammeln
+  konnten. Das Image installiert jetzt `tini` und nutzt es als
+  `ENTRYPOINT`, der Kindprozesse korrekt reaped. Zusätzlich aktiviert
+  `docker-compose.yml` `init: true` als Defense-in-Depth.
+
 ## [0.9.20] - 2026-04-19
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
+    apt-get install -y --no-install-recommends curl tini && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -30,4 +30,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1
 
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   icloud-backup:
     build: .
     container_name: icloud-backup
+    init: true
     restart: unless-stopped
     mem_limit: 512m
     # cpus: 1.0  # Requires kernel CFS scheduler support (not available on all Synology models)


### PR DESCRIPTION
## Summary
This PR fixes an issue where zombie `curl` processes were accumulating in the container due to the absence of a proper init system. The container was running `uvicorn` as PID 1, which cannot properly reap child processes.

## Changes
- **Dockerfile**: Added `tini` package installation and configured it as the container `ENTRYPOINT` to properly handle child process reaping
- **docker-compose.yml**: Enabled `init: true` as an additional defense-in-depth measure to ensure proper process management

## Implementation Details
The root cause was that Docker's `HEALTHCHECK` invokes `curl` via `sh -c` every 30 seconds. When these shell wrappers exit, their child processes get reparented to PID 1 (uvicorn). Since uvicorn doesn't implement init system behavior, it doesn't reap these zombie processes, causing them to accumulate over time.

The fix uses `tini` as a lightweight init system that properly handles signal forwarding and child process reaping. The `ENTRYPOINT` is set to `tini --` which then executes the uvicorn command as a child process. Additionally, `init: true` is enabled in docker-compose.yml to provide redundant zombie process handling at the Docker daemon level.

https://claude.ai/code/session_014ALAt8tyxFHxWybsVaGCrD